### PR TITLE
ログインユーザーが作成した議題ボード一覧閲覧機能を実装する

### DIFF
--- a/app/controllers/agenda_boards_controller.rb
+++ b/app/controllers/agenda_boards_controller.rb
@@ -18,6 +18,10 @@ class AgendaBoardsController < ApplicationController
     @agenda_board = AgendaBoard.find(params[:id])
   end
 
+  def index
+    @user_created_agenda_boards = AgendaBoard.where(user_id: current_user.id).order(created_at: :desc)
+  end
+
   private
 
   def agenda_board_params

--- a/app/views/agenda_boards/index.html.erb
+++ b/app/views/agenda_boards/index.html.erb
@@ -1,0 +1,19 @@
+<h3><%= current_user.name %>さんの作成した議題ボード一覧</h3>
+<table>
+  <thead>
+    <tr>
+      <th>議題</th>
+      <th>カテゴリ</th>
+      <th>作成日</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @user_created_agenda_boards.each do |user_created_agenda_board| %>
+    <tr>
+      <td><%= link_to user_created_agenda_board.agenda, agenda_board_path(user_created_agenda_board.id) %></td>
+      <td><%= user_created_agenda_board.category %></td>
+      <td><%= user_created_agenda_board.created_at %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
           <%= link_to 'プロフィール変更', edit_user_registration_path %>
           <%= link_to 'ログアウト', sign_out_path %>
           <%= link_to '新規議題ボード作成ページへ', new_agenda_board_path %>
+          <%= link_to "#{current_user.name}さんが作成した議題ボード", agenda_boards_path %>
         <% else %>
           <%= link_to 'サインアップ', sign_up_path %>
           <%= link_to 'ログイン', sign_in_path %>

--- a/spec/system/agenda_boards_spec.rb
+++ b/spec/system/agenda_boards_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.describe "AgendaBoards", type: :system do
   let(:annie) { create(:user, name: "annie") }
+  let!(:about_early_bird) { create(:agenda_board, user_id: annie.id, agenda: "早起きは健康によいのか?", category: "自然科学") }
+  let!(:about_chatbot) { create(:agenda_board, user_id: annie.id, agenda: "チャットボットは教育に悪影響を与えるのか?", category: "社会科学") }
 
   describe "新規議題ボード作成ページアクセス後" do
     before do
@@ -27,6 +29,31 @@ RSpec.describe "AgendaBoards", type: :system do
       scenario "作成した議題ボードの詳細ページに遷移すること" do
         expect(page).to have_current_path agenda_board_path(annie.agenda_boards.last.id)
       end
+    end
+  end
+
+  describe "ログインユーザーが作成した議題ボード一覧ページにアクセス後" do
+    before do
+      visit root_path
+      click_on "ログイン"
+      fill_in "メールアドレス", with: annie.email
+      fill_in "パスワード", with: annie.password
+      click_button "Log in"
+      click_on "#{annie.name}さんが作成した議題ボード"
+    end
+
+    scenario "議題ボードの議題名の一覧を動的に確認できる" do
+      save_and_open_page
+      annie.agenda_boards.all? { |agenda_board| expect(page).to have_content agenda_board.agenda }
+    end
+
+    scenario "議題ボードのカテゴリ名の一覧を動的に確認できる" do
+      annie.agenda_boards.all? { |agenda_board| expect(page).to have_content agenda_board.category }
+    end
+
+    scenario "議題名をクリックすると､その議題ボードの詳細ページに遷移すること" do
+      click_on about_early_bird.agenda
+      expect(page).to have_current_path agenda_board_path(about_early_bird.id)
     end
   end
 end

--- a/spec/system/agenda_boards_spec.rb
+++ b/spec/system/agenda_boards_spec.rb
@@ -5,13 +5,16 @@ RSpec.describe "AgendaBoards", type: :system do
   let!(:about_early_bird) { create(:agenda_board, user_id: annie.id, agenda: "早起きは健康によいのか?", category: "自然科学") }
   let!(:about_chatbot) { create(:agenda_board, user_id: annie.id, agenda: "チャットボットは教育に悪影響を与えるのか?", category: "社会科学") }
 
+  before do
+    visit root_path
+    click_on "ログイン"
+    fill_in "メールアドレス", with: annie.email
+    fill_in "パスワード", with: annie.password
+    click_button "Log in"
+  end
+
   describe "新規議題ボード作成ページアクセス後" do
     before do
-      visit root_path
-      click_on "ログイン"
-      fill_in "メールアドレス", with: annie.email
-      fill_in "パスワード", with: annie.password
-      click_button "Log in"
       click_on "新規議題ボード作成ページへ"
     end
 
@@ -34,16 +37,10 @@ RSpec.describe "AgendaBoards", type: :system do
 
   describe "ログインユーザーが作成した議題ボード一覧ページにアクセス後" do
     before do
-      visit root_path
-      click_on "ログイン"
-      fill_in "メールアドレス", with: annie.email
-      fill_in "パスワード", with: annie.password
-      click_button "Log in"
       click_on "#{annie.name}さんが作成した議題ボード"
     end
 
     scenario "議題ボードの議題名の一覧を動的に確認できる" do
-      save_and_open_page
       annie.agenda_boards.all? { |agenda_board| expect(page).to have_content agenda_board.agenda }
     end
 

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -57,6 +57,11 @@ RSpec.describe "Home", type: :system do
         click_on "新規議題ボード作成ページへ"
         expect(page).to have_current_path new_agenda_board_path
       end
+
+      scenario "｢**(現在ログイン中のユーザー名)さんが作成した議題ボード｣リンクを押すと､議題ボード一覧ページに遷移すること" do
+        click_on "#{annie.name}さんが作成した議題ボード"
+        expect(page).to have_current_path agenda_boards_path
+      end
     end
   end
 end


### PR DESCRIPTION
## 関連するチケット､Issue､プルリクエストのリンク

* #6 

## なぜこの変更をするのか

* ログインユーザーが､作成した議題ボードの一覧を閲覧できるようにするため｡

## やったこと
* ヘッダーリンク中の｢xxx(ログインユーザーのname)さんの作成した議題ボード｣リンクを押すと､作成した議題ボードの一覧を作成日時順(降順)で閲覧できる機能の実装
* ヘッダーリンクのシステムスペック追加
* 議題ボードの一覧ページのシステムスペック追加

## やらないこと

* 無し

## 変更内容

* ログイン後のヘッダーに｢**(ログインユーザーの名前)さんが作成した議題ボード｣リンクを追加した｡

**before**
![スクリーンショット 2023-04-05 14 47 23](https://user-images.githubusercontent.com/111355072/229992217-2ae98c27-e6d5-412f-8feb-ae35e200cc06.png)

**after**
![スクリーンショット 2023-04-05 14 46 18](https://user-images.githubusercontent.com/111355072/229992245-194a32b6-105b-4942-b47c-65f1a2165f7c.png)

尚､リンク押下後はログインユーザーが作成した議題ボード一覧ページに遷移する｡

* ログインユーザーが作成した議題ボード一覧ページを新規作成した｡
![スクリーンショット 2023-04-05 14 53 12](https://user-images.githubusercontent.com/111355072/229992951-b095d79b-a4cd-4f02-9fa7-ff5ad0c273d6.png)

議題名は､リンクになっており､クリックすると､議題ボード詳細ページに遷移する｡
![スクリーンショット 2023-04-05 14 56 29](https://user-images.githubusercontent.com/111355072/229993578-31eb9b14-9c27-4d12-95aa-7cfcef5e0dca.png)
=>
![スクリーンショット 2023-04-05 14 57 26](https://user-images.githubusercontent.com/111355072/229993605-254cef6f-097b-4cd9-92d7-ed8fd5851be0.png)
## できるようになること（ユーザ目線）

* 自身が作成した議題ボードの一覧を閲覧すること｡
* 議題ボード一覧ページ中の議題名をクリックすることで､議題ボード詳細ページに遷移すること｡

## できなくなること（ユーザ目線）

* なし

## 動作確認

* 開発環境において､システムスペックを実行することで､ヘッダーに追加したリンクのUIをテスト結果､そのテストをパスした｡
![スクリーンショット 2023-04-05 15 06 12](https://user-images.githubusercontent.com/111355072/229995344-952d90d7-63aa-452b-a0b7-3d9f9b57ae2f.png)

* 同様に､ログインユーザーが作成した議題ボード一覧ページのUIをテストした結果､全テストをパスした｡
![スクリーンショット 2023-04-05 15 08 02](https://user-images.githubusercontent.com/111355072/229995368-943fb601-49ca-48be-8f4b-500ec6f914ac.png)


## その他

* 無し
