### PR TITLE
新規主張を作成し､閲覧する機能を実装する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,5 @@ gem 'devise-i18n'
 gem 'devise-i18n-views'
 gem 'pry-rails'
 gem 'rails-i18n'
+gem 'cocoon'
+gem "jquery-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cocoon (1.2.15)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
@@ -102,6 +103,10 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.5.1)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     json (2.6.3)
     launchy (2.5.2)
       addressable (~> 2.8)
@@ -308,11 +313,13 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  cocoon
   devise
   devise-i18n
   devise-i18n-views
   factory_bot_rails
   jbuilder (~> 2.7)
+  jquery-rails
   launchy
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/agenda_boards_controller.rb
+++ b/app/controllers/agenda_boards_controller.rb
@@ -16,6 +16,7 @@ class AgendaBoardsController < ApplicationController
 
   def show
     @agenda_board = AgendaBoard.find(params[:id])
+    @conclusions = @agenda_board.conclusions
   end
 
   def index

--- a/app/controllers/arguments_controller.rb
+++ b/app/controllers/arguments_controller.rb
@@ -10,12 +10,10 @@ class ArgumentsController < ApplicationController
 
   def create
     argument = Conclusion.new(argument_params)
-
-    binding.pry
-
     if argument.valid?
       flash[:notice] = "新規主張の作成に成功しました"
       argument.save!
+      redirect_to agenda_board_path(argument.agenda_board_id)
     else
       flash[:notice] = "新規主張の作成に失敗しました｡"
       render :new

--- a/app/controllers/arguments_controller.rb
+++ b/app/controllers/arguments_controller.rb
@@ -26,8 +26,8 @@ class ArgumentsController < ApplicationController
 
   def argument_params
     params.require(:conclusion).permit(:agenda_board_id, :conclusion_summary, :conclusion_detail,
-      reasons_attributes: [:reason_summary, :reason_detail,
-        evidences_attributes: [:evidence_summary, :evidence_detail]
+      reasons_attributes: [:id, :reason_summary, :reason_detail, :_destroy,
+        evidences_attributes: [:id, :evidence_summary, :evidence_detail, :_destroy]
       ]
     )
   end

--- a/app/controllers/arguments_controller.rb
+++ b/app/controllers/arguments_controller.rb
@@ -24,9 +24,9 @@ class ArgumentsController < ApplicationController
 
   def argument_params
     params.require(:conclusion).permit(:agenda_board_id, :conclusion_summary, :conclusion_detail,
-      reasons_attributes: [:id, :reason_summary, :reason_detail, :_destroy,
-        evidences_attributes: [:id, :evidence_summary, :evidence_detail, :_destroy]
-      ]
-    )
+      reasons_attributes: [
+        :id, :reason_summary, :reason_detail, :_destroy,
+        evidences_attributes: [:id, :evidence_summary, :evidence_detail, :_destroy],
+      ])
   end
 end

--- a/app/controllers/arguments_controller.rb
+++ b/app/controllers/arguments_controller.rb
@@ -1,0 +1,34 @@
+class ArgumentsController < ApplicationController
+  def new
+    @agenda_board_id = params[:agenda_board_id].to_i
+    @agenda_board_agenda = params[:agenda_board_agenda]
+
+    @conclusion = Conclusion.new
+    reasons = @conclusion.reasons.build
+    reasons.evidences.build
+  end
+
+  def create
+    argument = Conclusion.new(argument_params)
+
+    binding.pry
+
+    if argument.valid?
+      flash[:notice] = "新規主張の作成に成功しました"
+      argument.save!
+    else
+      flash[:notice] = "新規主張の作成に失敗しました｡"
+      render :new
+    end
+  end
+
+  private
+
+  def argument_params
+    params.require(:conclusion).permit(:agenda_board_id, :conclusion_summary, :conclusion_detail,
+      reasons_attributes: [:reason_summary, :reason_detail,
+        evidences_attributes: [:evidence_summary, :evidence_detail]
+      ]
+    )
+  end
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -15,3 +15,5 @@ require("channels")
 //
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
+require("jquery")
+require("@nathanvda/cocoon")

--- a/app/models/agenda_board.rb
+++ b/app/models/agenda_board.rb
@@ -1,3 +1,4 @@
 class AgendaBoard < ApplicationRecord
   belongs_to :user
+  has_many :conclusions
 end

--- a/app/models/conclusion.rb
+++ b/app/models/conclusion.rb
@@ -1,0 +1,2 @@
+class Conclusion < ApplicationRecord
+end

--- a/app/models/conclusion.rb
+++ b/app/models/conclusion.rb
@@ -1,3 +1,4 @@
 class Conclusion < ApplicationRecord
   belong_to :agenda_board
+  has_many :reasons
 end

--- a/app/models/conclusion.rb
+++ b/app/models/conclusion.rb
@@ -1,2 +1,3 @@
 class Conclusion < ApplicationRecord
+  belong_to :agenda_board
 end

--- a/app/models/conclusion.rb
+++ b/app/models/conclusion.rb
@@ -1,7 +1,7 @@
 class Conclusion < ApplicationRecord
   belongs_to :agenda_board
-  has_many :reasons
-  accepts_nested_attributes_for :reasons
+  has_many :reasons, dependent: :destroy
+  accepts_nested_attributes_for :reasons, allow_destroy: true
 
   validates :agenda_board_id, presence: true
   validates :conclusion_summary, presence: true

--- a/app/models/conclusion.rb
+++ b/app/models/conclusion.rb
@@ -1,4 +1,8 @@
 class Conclusion < ApplicationRecord
   belongs_to :agenda_board
   has_many :reasons
+  accepts_nested_attributes_for :reasons
+
+  validates :agenda_board_id, presence: true
+  validates :conclusion_summary, presence: true
 end

--- a/app/models/conclusion.rb
+++ b/app/models/conclusion.rb
@@ -1,4 +1,4 @@
 class Conclusion < ApplicationRecord
-  belong_to :agenda_board
+  belongs_to :agenda_board
   has_many :reasons
 end

--- a/app/models/evidence.rb
+++ b/app/models/evidence.rb
@@ -1,0 +1,2 @@
+class Evidence < ApplicationRecord
+end

--- a/app/models/evidence.rb
+++ b/app/models/evidence.rb
@@ -1,3 +1,3 @@
 class Evidence < ApplicationRecord
-  belong_to :reason
+  belongs_to :reason
 end

--- a/app/models/evidence.rb
+++ b/app/models/evidence.rb
@@ -1,3 +1,5 @@
 class Evidence < ApplicationRecord
   belongs_to :reason
+
+  validates :evidence_summary, presence: true
 end

--- a/app/models/evidence.rb
+++ b/app/models/evidence.rb
@@ -1,2 +1,3 @@
 class Evidence < ApplicationRecord
+  belong_to :reason
 end

--- a/app/models/reason.rb
+++ b/app/models/reason.rb
@@ -1,0 +1,2 @@
+class Reason < ApplicationRecord
+end

--- a/app/models/reason.rb
+++ b/app/models/reason.rb
@@ -1,3 +1,4 @@
 class Reason < ApplicationRecord
   belong_to :conclusion
+  has_many :evidences
 end

--- a/app/models/reason.rb
+++ b/app/models/reason.rb
@@ -1,7 +1,7 @@
 class Reason < ApplicationRecord
   belongs_to :conclusion
-  has_many :evidences
-  accepts_nested_attributes_for :evidences
+  has_many :evidences, dependent: :destroy
+  accepts_nested_attributes_for :evidences, allow_destroy: true
 
   validates :reason_summary, presence: true
 end

--- a/app/models/reason.rb
+++ b/app/models/reason.rb
@@ -1,4 +1,7 @@
 class Reason < ApplicationRecord
   belongs_to :conclusion
   has_many :evidences
+  accepts_nested_attributes_for :evidences
+
+  validates :reason_summary, presence: true
 end

--- a/app/models/reason.rb
+++ b/app/models/reason.rb
@@ -1,2 +1,3 @@
 class Reason < ApplicationRecord
+  belong_to :conclusion
 end

--- a/app/models/reason.rb
+++ b/app/models/reason.rb
@@ -1,4 +1,4 @@
 class Reason < ApplicationRecord
-  belong_to :conclusion
+  belongs_to :conclusion
   has_many :evidences
 end

--- a/app/views/agenda_boards/show.html.erb
+++ b/app/views/agenda_boards/show.html.erb
@@ -1,4 +1,45 @@
 <div class="agenda">
-  <%= @agenda_board.agenda %>
+  <h1><%= @agenda_board.agenda %></h1>
+  <% @conclusions.each do |conclusion| %>
+    <table>
+      <tr>
+        <th><%= current_user.name %>さんの主張</th>
+      </tr>
+      <tr>
+        <th>結論</th>
+        <td><%= conclusion.conclusion_summary %></td>
+      </tr>
+      <tr>
+        <th>結論詳細</th>
+        <td><%= conclusion.conclusion_detail %></td>
+      </tr>
+    </table>
+
+    <% conclusion.reasons.each do |reason| %>
+      <table>
+        <tr>
+          <th>理由</th>
+          <td><%= reason.reason_summary %></td>
+        </tr>
+        <tr>
+          <th>理由詳細</th>
+          <td><%= reason.reason_detail %></td>
+        </tr>
+      </table>
+
+      <% reason.evidences.each do |evidence| %>
+        <table>
+          <tr>
+            <th>証拠</th>
+            <td><%= evidence.evidence_summary %></td>
+          </tr>
+          <tr>
+            <th>証拠詳細</th>
+            <td><%= evidence.evidence_detail %></td>
+          </tr>
+        </table>
+      <% end %>
+    <% end %>
+  <% end %>
   <%= button_to "新規主張作成", new_argument_path, method: :get, params: {agenda_board_id: @agenda_board.id, agenda_board_agenda: @agenda_board.agenda} %>
 </div>

--- a/app/views/agenda_boards/show.html.erb
+++ b/app/views/agenda_boards/show.html.erb
@@ -1,3 +1,4 @@
 <div class="agenda">
   <%= @agenda_board.agenda %>
+  <%= button_to "新規主張作成", new_argument_path, method: :get, params: {agenda_board_id: @agenda_board.id, agenda_board_agenda: @agenda_board.agenda} %>
 </div>

--- a/app/views/arguments/_evidence_fields.html.erb
+++ b/app/views/arguments/_evidence_fields.html.erb
@@ -1,0 +1,7 @@
+<div class="nested-fields">
+    <%= f.label :evidence_summary, "証拠概要" %>
+    <%= f.text_field :evidence_summary %>
+    <%= f.label :evidence_detail, "証拠詳細" %>
+    <%= f.text_area :evidence_detail %>
+    <%= link_to_remove_association "証拠を削除", f %>
+</div>

--- a/app/views/arguments/_evidence_fields.html.erb
+++ b/app/views/arguments/_evidence_fields.html.erb
@@ -1,5 +1,5 @@
 <div class="nested-fields">
-    <%= f.label :evidence_summary, "証拠概要" %>
+    <%= f.label :evidence_summary, "証拠" %>
     <%= f.text_field :evidence_summary %>
     <%= f.label :evidence_detail, "証拠詳細" %>
     <%= f.text_area :evidence_detail %>

--- a/app/views/arguments/_reason_fields.html.erb
+++ b/app/views/arguments/_reason_fields.html.erb
@@ -1,5 +1,5 @@
 <div class="nested-fields">
-    <%= f.label :reason_summary, "理由概要" %>
+    <%= f.label :reason_summary, "理由" %>
     <%= f.text_field :reason_summary %>
     <%= f.label :reason_detail, "理由詳細" %>
     <%= f.text_area :reason_detail %>

--- a/app/views/arguments/_reason_fields.html.erb
+++ b/app/views/arguments/_reason_fields.html.erb
@@ -1,0 +1,17 @@
+<div class="nested-fields">
+    <%= f.label :reason_summary, "理由概要" %>
+    <%= f.text_field :reason_summary %>
+    <%= f.label :reason_detail, "理由詳細" %>
+    <%= f.text_area :reason_detail %>
+    <%= link_to_remove_association "理由を削除", f %>
+
+    <%= f.fields_for :evidences do |evidence| %>
+        <%= render "evidence_fields", f: evidence %>
+    <% end %>
+
+    <%= link_to_add_association "証拠を追加", f, :evidences,
+        data: {
+            association_insertion_method: 'after'
+        }
+    %>
+</div>

--- a/app/views/arguments/new.html.erb
+++ b/app/views/arguments/new.html.erb
@@ -2,7 +2,7 @@
 <h2>新規主張</h2>
 <%= form_with model: @conclusion, url: arguments_path, local: true do |f| %>
   <%= f.hidden_field :agenda_board_id, value: @agenda_board_id %>
-  <%= f.label :conclusion_summary, "結論概要" %>
+  <%= f.label :conclusion_summary, "結論" %>
   <%= f.text_field :conclusion_summary %>
   <%= f.label :conclusion_detail, "結論詳細" %>
   <%= f.text_area :conclusion_detail %>

--- a/app/views/arguments/new.html.erb
+++ b/app/views/arguments/new.html.erb
@@ -1,23 +1,21 @@
 <h1><%= @agenda_board_agenda %></h1>
-<%= form_with model: @conclusion, url: arguments_path do |f| %>
+<h2>新規主張</h2>
+<%= form_with model: @conclusion, url: arguments_path, local: true do |f| %>
   <%= f.hidden_field :agenda_board_id, value: @agenda_board_id %>
   <%= f.label :conclusion_summary, "結論概要" %>
   <%= f.text_field :conclusion_summary %>
   <%= f.label :conclusion_detail, "結論詳細" %>
   <%= f.text_area :conclusion_detail %>
 
-  <%= f.fields_for :reasons do |reason| %>
-    <%= reason.label :reason_summary, "理由概要" %>
-    <%= reason.text_field :reason_summary %>
-    <%= reason.label :reason_detail, "理由詳細" %>
-    <%= reason.text_area :reason_detail %>
-
-    <%= reason.fields_for :evidences do |evidence| %>
-      <%= evidence.label :evidence_summary, "証拠概要" %>
-      <%= evidence.text_field :evidence_summary %>
-      <%= evidence.label :evidence_detail, "証拠詳細" %>
-      <%= evidence.text_area :evidence_detail %>
+  <div class="reasons">
+    <%= f.fields_for :reasons do |reason| %>
+      <%= render "reason_fields", f: reason %>
     <% end %>
-  <% end %>
-  <%= f.submit "新規主張を作成する" %>
+    <div class="links">
+      <%= link_to_add_association "理由を追加", f, :reasons %>
+    </div>
+  </div>
+  <div>
+    <%= f.submit "新規主張を作成する" %>
+  </div>
 <% end %>

--- a/app/views/arguments/new.html.erb
+++ b/app/views/arguments/new.html.erb
@@ -1,0 +1,23 @@
+<h1><%= @agenda_board_agenda %></h1>
+<%= form_with model: @conclusion, url: arguments_path do |f| %>
+  <%= f.hidden_field :agenda_board_id, value: @agenda_board_id %>
+  <%= f.label :conclusion_summary, "結論概要" %>
+  <%= f.text_field :conclusion_summary %>
+  <%= f.label :conclusion_detail, "結論詳細" %>
+  <%= f.text_area :conclusion_detail %>
+
+  <%= f.fields_for :reasons do |reason| %>
+    <%= reason.label :reason_summary, "理由概要" %>
+    <%= reason.text_field :reason_summary %>
+    <%= reason.label :reason_detail, "理由詳細" %>
+    <%= reason.text_area :reason_detail %>
+
+    <%= reason.fields_for :evidences do |evidence| %>
+      <%= evidence.label :evidence_summary, "証拠概要" %>
+      <%= evidence.text_field :evidence_summary %>
+      <%= evidence.label :evidence_detail, "証拠詳細" %>
+      <%= evidence.text_area :evidence_detail %>
+    <% end %>
+  <% end %>
+  <%= f.submit "新規主張を作成する" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,5 @@ Rails.application.routes.draw do
     get 'sign_out', :to => 'users/sessions#destroy'
   end
 
-  resources :agenda_boards
+  resources :agenda_boards, :arguments
 end

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,11 @@
 const { environment } = require('@rails/webpacker')
 
+const webpack = require('webpack')
+environment.plugins.prepend('Provide',
+    new webpack.ProvidePlugin({
+        $: 'jquery/src/jquery',
+        jQuery: 'jquery/src/jquery'
+    })
+)
+
 module.exports = environment

--- a/db/migrate/20230408042123_create_conclusions.rb
+++ b/db/migrate/20230408042123_create_conclusions.rb
@@ -1,0 +1,11 @@
+class CreateConclusions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :conclusions do |t|
+      t.integer :agenda_board_id
+      t.string :conclusion_summary
+      t.text :conclusion_detail
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230408043607_create_reasons.rb
+++ b/db/migrate/20230408043607_create_reasons.rb
@@ -1,0 +1,11 @@
+class CreateReasons < ActiveRecord::Migration[6.0]
+  def change
+    create_table :reasons do |t|
+      t.integer :conclusion_id
+      t.string :reason_summary
+      t.text :reason_detail
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230408044932_create_evidences.rb
+++ b/db/migrate/20230408044932_create_evidences.rb
@@ -1,0 +1,11 @@
+class CreateEvidences < ActiveRecord::Migration[6.0]
+  def change
+    create_table :evidences do |t|
+      t.integer :reason_id
+      t.string :evidence_summary
+      t.text :evidence_detail
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_08_042123) do
+ActiveRecord::Schema.define(version: 2023_04_08_043607) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,14 @@ ActiveRecord::Schema.define(version: 2023_04_08_042123) do
     t.integer "agenda_board_id"
     t.string "conclusion_summary"
     t.text "conclusion_detail"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "reasons", force: :cascade do |t|
+    t.integer "conclusion_id"
+    t.string "reason_summary"
+    t.text "reason_detail"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_31_020906) do
+ActiveRecord::Schema.define(version: 2023_04_08_042123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,6 +19,14 @@ ActiveRecord::Schema.define(version: 2023_03_31_020906) do
     t.integer "user_id"
     t.string "agenda"
     t.string "category"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "conclusions", force: :cascade do |t|
+    t.integer "agenda_board_id"
+    t.string "conclusion_summary"
+    t.text "conclusion_detail"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_08_043607) do
+ActiveRecord::Schema.define(version: 2023_04_08_044932) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,14 @@ ActiveRecord::Schema.define(version: 2023_04_08_043607) do
     t.integer "agenda_board_id"
     t.string "conclusion_summary"
     t.text "conclusion_detail"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "evidences", force: :cascade do |t|
+    t.integer "reason_id"
+    t.string "evidence_summary"
+    t.text "evidence_detail"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "VisualDiscussion",
   "private": true,
   "dependencies": {
+    "@nathanvda/cocoon": "^1.2.14",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.3",
+    "jquery": "^3.6.4",
     "turbolinks": "^5.2.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"

--- a/spec/factories/conclusions.rb
+++ b/spec/factories/conclusions.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :conclusion do
+    agenda_board_id { 1 }
+    conclusion_summary { "MyString" }
+    conclusion_detail { "MyText" }
+  end
+end

--- a/spec/factories/evidences.rb
+++ b/spec/factories/evidences.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :evidence do
+    reason_id { 1 }
+    evidence_summary { "MyString" }
+    evidence_detail { "MyText" }
+  end
+end

--- a/spec/factories/reasons.rb
+++ b/spec/factories/reasons.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :reason do
+    conclusion_id { 1 }
+    reason_summary { "MyString" }
+    reason_detail { "MyText" }
+  end
+end

--- a/spec/models/conclusion_spec.rb
+++ b/spec/models/conclusion_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Conclusion, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/evidence_spec.rb
+++ b/spec/models/evidence_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Evidence, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/reason_spec.rb
+++ b/spec/models/reason_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Reason, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/system/agenda_boards_spec.rb
+++ b/spec/system/agenda_boards_spec.rb
@@ -2,8 +2,14 @@ require 'rails_helper'
 
 RSpec.describe "AgendaBoards", type: :system do
   let(:annie) { create(:user, name: "annie") }
-  let!(:about_early_bird) { create(:agenda_board, user_id: annie.id, agenda: "早起きは健康によいのか?", category: "自然科学") }
+  let(:about_early_bird) { create(:agenda_board, user_id: annie.id, agenda: "早起きは健康によいのか?", category: "自然科学") }
   let!(:about_chatbot) { create(:agenda_board, user_id: annie.id, agenda: "チャットボットは教育に悪影響を与えるのか?", category: "社会科学") }
+  let(:bad_for_health) { create(:conclusion, agenda_board_id: about_early_bird.id, conclusion_summary: "健康に悪い") }
+  let!(:good_for_health) { create(:conclusion, agenda_board_id: about_early_bird.id, conclusion_summary: "健康に良い") }
+  let(:misalignment_with_body_clock) { create(:reason, conclusion_id: bad_for_health.id, reason_summary: "人間の体内時計と噛み合っていないから") }
+  let!(:lack_of_sleep) { create(:reason, conclusion_id: bad_for_health.id, reason_summary: "睡眠不足になりやすいから") }
+  let!(:sleep_data) { create(:evidence, reason_id: misalignment_with_body_clock.id, evidence_summary: "世界中のあらゆる人々の睡眠データ") }
+  let!(:research_of_dr_kelly) { create(:evidence, reason_id: misalignment_with_body_clock.id, evidence_summary: "ケリー博士の研究") }
 
   before do
     visit root_path
@@ -63,6 +69,23 @@ RSpec.describe "AgendaBoards", type: :system do
     scenario "｢新規主張作成｣ボタンをクリックすると､新規主張作成ページに遷移すること" do
       click_button "新規主張作成"
       expect(page).to have_current_path new_argument_path, ignore_query: true
+    end
+
+    scenario "すべての主張(結論+理由+証拠)を動的に確認できること" do
+      about_early_bird.conclusions.all? do |conclusion|
+        expect(page).to have_content conclusion.conclusion_summary
+        expect(page).to have_content conclusion.conclusion_detail
+
+        conclusion.reasons.all? do |reason|
+          expect(page).to have_content reason.reason_summary
+          expect(page).to have_content reason.reason_summary
+
+          reason.evidences.all? do |evidence|
+            expect(page).to have_content evidence.evidence_summary
+            expect(page).to have_content evidence.evidence_detail
+          end
+        end
+      end
     end
   end
 end

--- a/spec/system/agenda_boards_spec.rb
+++ b/spec/system/agenda_boards_spec.rb
@@ -53,4 +53,16 @@ RSpec.describe "AgendaBoards", type: :system do
       expect(page).to have_current_path agenda_board_path(about_early_bird.id)
     end
   end
+
+  describe "議題ボード詳細ページアクセス後" do
+    before do
+      click_on "#{annie.name}さんが作成した議題ボード"
+      click_on about_early_bird.agenda
+    end
+
+    scenario "｢新規主張作成｣ボタンをクリックすると､新規主張作成ページに遷移すること" do
+      click_button "新規主張作成"
+      expect(page).to have_current_path new_argument_path, ignore_query: true
+    end
+  end
 end

--- a/spec/system/arguments_spec.rb
+++ b/spec/system/arguments_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe "Arguments", type: :system do
+  let(:annie) { create(:user, name: "annie") }
+  let!(:about_early_bird) { create(:agenda_board, user_id: annie.id, agenda: "早起きは健康によいのか?", category: "自然科学") }
+
+  before do
+    visit root_path
+    click_on "ログイン"
+    fill_in "メールアドレス", with: annie.email
+    fill_in "パスワード", with: annie.password
+    click_button "Log in"
+  end
+
+  describe "新規主張作成ページにアクセス後" do
+    before do
+      click_on "#{annie.name}さんが作成した議題ボード"
+      click_on about_early_bird.agenda
+      click_button "新規主張作成"
+    end
+
+    describe "必要事項を入力して､｢新規主張を作成する｣ボタンを押すと" do
+      before do
+        fill_in "結論", with: "健康に悪い"
+        fill_in "結論詳細", with: "体と心の健康に悪い"
+        fill_in "理由", with: "人間の体内時計と噛み合っていないから"
+        fill_in "理由詳細", with: "青年期(15~30歳)の最適な起床時間は朝9時だから"
+        fill_in "証拠", with: "ケリー博士の研究"
+        fill_in "証拠詳細", with: "https://www.researchgate.net/profile/Paul-Kelley-4"
+        click_button "新規主張を作成する"
+      end
+
+      scenario "新たな主張が作成されること" do
+        expect(page).to have_content "新規主張の作成に成功しました"
+      end
+
+      scenario "主張が所属する議題ボード詳細ページに遷移すること" do
+        expect(page).to have_current_path agenda_board_path(about_early_bird.id)
+      end
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -980,6 +980,13 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@nathanvda/cocoon@^1.2.14":
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/@nathanvda/cocoon/-/cocoon-1.2.14.tgz#aaea910e4b9c0d28d5bdcb7f3743617db46b09af"
+  integrity sha512-WcEt2vVp50de2i7rkD4O+96O1iMtMIcTBNGPocrHfcmHDujKOngoLHFF8Ektgoh8PjwFAJMxx8WyGv0BtKTjxQ==
+  dependencies:
+    jquery "^3.3.1"
+
 "@npmcli/fs@^1.0.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-1.1.1.tgz#72f719fe935e687c56a4faecf3c03d06ba593257"
@@ -4005,6 +4012,11 @@ jest-worker@^26.5.0:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
+
+jquery@^3.3.1, jquery@^3.6.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.4.tgz#ba065c188142100be4833699852bf7c24dc0252f"
+  integrity sha512-v28EW9DWDFpzcD9O5iyJXg3R3+q+mET5JhnjJzQUZMHOv67bpSIHq81GEYpPNZHG+XXHsfSme3nxp/hndKEcsQ==
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## 関連するチケット､Issue､プルリクエストのリンク

* #8

## なぜこの変更をするのか

* ログインユーザーが､議題ボード上に､新規主張を作成したり､閲覧したりすることを可能にするため｡

## やったこと

* 議題ボード詳細ページに､新規結論作成ページへのパスを持つ｢新規主張作成｣ボタンを追加
* 新規主張作成ページの作成
→ 必要事項入力後､｢新規主張を作成する｣ボタンを押すと､入力内容がDBに保存され､元いた議題ボード詳細ページに遷移する｡
→ ｢理由を追加｣｢理由を削除｣｢証拠を追加｣｢証拠を削除｣ボタンを押すと､各々のフォームの追加や削除が可能｡
* 議題ボード詳細ページに､作成された主張の一覧を表示する機能を追加



## やらないこと

* 新規主張作成ページのフォーム追加(js処理を伴う)に関するシステムスペックの実装 
→ 実装の仕方が分かり次第､実装する｡

## 変更内容

###  議題ボード詳細ページに､新規結論作成ページへのパスを持つ｢新規主張作成｣ボタンを追加
**before**
![スクリーンショット 2023-04-14 14 34 03](https://user-images.githubusercontent.com/111355072/231950242-b03e9630-bf34-4e35-89a7-7efe5512cece.png)

**after**
![スクリーンショット 2023-04-14 16 00 28](https://user-images.githubusercontent.com/111355072/231969076-cbb50372-e40a-4cb9-925e-939fb28228ed.png)


* ｢新規主張作成｣ボタンをクリックすると､新規主張作成ページに遷移する

![スクリーンショット 2023-04-14 16 05 39](https://user-images.githubusercontent.com/111355072/231969568-23f73096-5537-42dc-a75b-3c9fc848b02d.png)

=>

![スクリーンショット 2023-04-14 16 07 36](https://user-images.githubusercontent.com/111355072/231969755-1f698bd3-9144-4928-88ce-43a82cf67727.png)



###  新規主張作成ページの作成
**before**
無し
**after**
![スクリーンショット 2023-04-14 16 07 36](https://user-images.githubusercontent.com/111355072/231969774-75b9b1d8-edfd-4d9c-b673-dd5256ea5f0e.png)


*  ｢理由を追加｣｢理由を削除｣｢証拠を追加｣｢証拠を削除｣ボタンを押すと､各々のフォームの追加や削除ができる
![スクリーンショット 2023-04-14 16 24 40](https://user-images.githubusercontent.com/111355072/231973731-25fb619a-ed6d-469f-8760-25b5365106bc.png)
=>

**写真A**
![スクリーンショット 2023-04-14 16 22 09](https://user-images.githubusercontent.com/111355072/231973874-b0ed1a82-7f7c-4db7-b36d-33a66f18b7f4.png)


**写真B**
![スクリーンショット 2023-04-14 16 28 02](https://user-images.githubusercontent.com/111355072/231974020-09524820-ef65-4928-b88b-5eabb9e44f63.png)


**写真C**
![スクリーンショット 2023-04-14 16 28 58](https://user-images.githubusercontent.com/111355072/231975361-39c3d5a2-fee2-4bd0-9280-c6cf23a50689.png)


**写真D**
![スクリーンショット 2023-04-14 16 33 12](https://user-images.githubusercontent.com/111355072/231976017-06227bca-1a44-4f0e-bb07-f793320ed98d.png)


* 必要事項を入力して､｢新規主張を作成する｣ボタンを押すと､入力内容がDBに保存され､元の議題ボード詳細ページに遷移する｡
![スクリーンショット 2023-04-14 16 12 22](https://user-images.githubusercontent.com/111355072/231971043-aadc5221-2160-41b9-b852-94c290ce6622.png)

=>

![スクリーンショット 2023-04-14 16 15 25](https://user-images.githubusercontent.com/111355072/231971425-1f7213c0-51fe-4c2f-911a-47ae2002b106.png)

### 議題ボード詳細ページに､作成された主張の一覧を表示する機能を追加
**before**
![スクリーンショット 2023-04-14 14 34 03](https://user-images.githubusercontent.com/111355072/231951697-563cdae1-69ab-493a-931f-c32c0f696a61.png)

**after**

![スクリーンショット 2023-04-14 16 16 32](https://user-images.githubusercontent.com/111355072/231971734-6855fe7f-c37d-42ca-bd7f-84d84f8fb87b.png)

## できるようになること（ユーザ目線）

* 議題ボード詳細ページにて､｢新規主張作成｣ボタンを押すと､新規主張作成ページに遷移する｡
必要事項を入力して､｢作成｣ボタンを押すと､議題ボード詳細ページに遷移し､作成された主張を閲覧することができる｡

## できなくなること（ユーザ目線）

* 無し

## 動作確認

### 議題ボード詳細ページ
開発環境において､システムスペックを実装することで､追加したUIをテストした結果､すべてのテストをパスした｡
![スクリーンショット 2023-04-14 15 41 02](https://user-images.githubusercontent.com/111355072/231964014-f2817af8-d32b-4e7f-a7c1-5505033c92c2.png)


### 新規主張作成ページ
上と同様の方法で､追加したUIをテストした結果､すべてのテストをパスした｡
![スクリーンショット 2023-04-14 15 46 18](https://user-images.githubusercontent.com/111355072/231965277-237a3e78-da4c-47fe-9163-bd765e2e7948.png)


## その他

主に以下のサイトを参考に実装を行った｡
>accepts_nested_attributes_forメソッドに関して
[https://railsguides.jp/form_helpers.html#複雑なフォームを作成する](https://railsguides.jp/form_helpers.html#%E8%A4%87%E9%9B%91%E3%81%AA%E3%83%95%E3%82%A9%E3%83%BC%E3%83%A0%E3%82%92%E4%BD%9C%E6%88%90%E3%81%99%E3%82%8B)

>conconを用いた､新規主張作成ページに実装に関して
https://qiita.com/kmjooh/items/a1613531873a22fa7862
https://github.com/nathanvda/cocoon
https://qiita.com/ashketcham/items/87e3db665ca9c66ce673
https://qiita.com/hitochan/items/5a45a95e644492d66160
https://qiita.com/matata0623/items/8868a7fcb6ec0817d064

