### PR TITLE
主張の見た目と挙動を整える

### DIFF
--- a/app/assets/stylesheets/agenda_boards.scss
+++ b/app/assets/stylesheets/agenda_boards.scss
@@ -1,5 +1,5 @@
 // 主張と反論のレイアウト
-.claimant_name {
+.type_of_opinion {
   background: #0094D6;
   color: #FFF;
   margin: 0;

--- a/app/assets/stylesheets/agenda_boards.scss
+++ b/app/assets/stylesheets/agenda_boards.scss
@@ -1,3 +1,61 @@
-// Place all the styles related to the AgendaBoards controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/
+.claimant_name {
+  background: #0094D6;
+  color: #FFF;
+  margin: 0;
+  display:inline-block;
+  padding: .3em .5em;
+  border-radius: 10px 10px 0 0;
+}
+
+.argument {
+  border: 2px solid #0094D6;
+  padding: 10px;
+  width: fit-content;
+}
+
+.conclusion {
+  margin: 0 auto;
+}
+
+.endpoint {
+  background-color: aquamarine;
+  width: 20px;
+  height: 20px;
+  margin: 40px auto;
+}
+
+.bases {
+  display: flex;
+}
+
+.reason {
+  margin: 0 auto;
+}
+
+.evidences {
+  display: flex;
+}
+
+.evidence {
+  margin: 0 5px;
+}
+
+.box .inner {
+  padding: .5em;
+}
+
+.box {
+  border: 2px solid #0094D6;
+  width: 200px;
+}
+
+.box h3 {
+  background: #0094D6;
+  color: #FFF;
+  text-align: center;
+  margin: 0;
+}
+
+.inner {
+  word-break: break-all;
+}

--- a/app/assets/stylesheets/agenda_boards.scss
+++ b/app/assets/stylesheets/agenda_boards.scss
@@ -1,3 +1,4 @@
+// 主張と反論のレイアウト
 .claimant_name {
   background: #0094D6;
   color: #FFF;
@@ -7,13 +8,13 @@
   border-radius: 10px 10px 0 0;
 }
 
-.argument {
+.tree_structure {
   border: 2px solid #0094D6;
   padding: 10px;
   width: fit-content;
 }
 
-.conclusion {
+.conclusion, .ref_conclusion {
   margin: 0 auto;
 }
 

--- a/app/assets/stylesheets/agenda_boards.scss
+++ b/app/assets/stylesheets/agenda_boards.scss
@@ -38,7 +38,7 @@
 }
 
 .evidence {
-  margin: 0 5px;
+  margin: 0 10px;
 }
 
 .box .inner {

--- a/app/assets/stylesheets/agenda_boards.scss
+++ b/app/assets/stylesheets/agenda_boards.scss
@@ -60,3 +60,8 @@
 .inner {
   word-break: break-all;
 }
+
+// 主張と反論をドラッグ可能にする
+.argument, .refutation {
+  position: absolute;
+}

--- a/app/assets/stylesheets/agenda_boards.scss
+++ b/app/assets/stylesheets/agenda_boards.scss
@@ -65,3 +65,10 @@
 .argument, .refutation {
   position: absolute;
 }
+
+// 接続線がエンドポイントの下にくるようにする
+// https://docs.jsplumbtoolkit.com/community/lib/styling-via-css
+.window { z-index:20; }
+.jtk-connector { z-index:4; }
+.jtk-endpoint { z-index:5; }
+.jtk-overlay { z-index:6; }

--- a/app/assets/stylesheets/agenda_boards.scss
+++ b/app/assets/stylesheets/agenda_boards.scss
@@ -72,3 +72,13 @@
 .jtk-connector { z-index:4; }
 .jtk-endpoint { z-index:5; }
 .jtk-overlay { z-index:6; }
+
+// 接続線を右クリックしたときに､表示される｢削除ボタン｣のレイアウト
+// https://stackoverflow.com/a/4502207
+.custom-menu {
+  z-index: 1000;
+  position: absolute;
+  background-color: #C0C0C0;
+  border: 1px solid black;
+  padding: 2px;
+}

--- a/app/javascript/packs/argument.js
+++ b/app/javascript/packs/argument.js
@@ -24,7 +24,14 @@ jsPlumb.ready(function() {
     }
   });
 
-  // 反論をドラッグ可能にし､リロード後も反論の位置が再現されるようにする
+  // 反論をドラッグ可能にし､リロード後も反論の位置が再現されるようにする + 反論の左上にソースエンドポイントを設置する
+  jsPlumb.registerConnectionTypes({
+    "red-connection": {
+      paintStyle: {stroke: "red", strokeWidth: 5},
+      hoverPaintStyle: {stroke: "red", strokeWidth: 10}
+    }
+  });
+
   const all_refutations = document.querySelectorAll(".refutation");
   all_refutations.forEach( function( refutation ) {
     const refutation_id = refutation.getAttribute("id");
@@ -43,17 +50,17 @@ jsPlumb.ready(function() {
     if (refutation_position) {
       $(`#${refutation_id}`).css({left: refutation_position.left + "px", top: refutation_position.top + "px"});
     }
-  });
 
+    // 反論の左上にソースエンドポイントを設置する
+    jsPlumb.addEndpoint(`${refutation_id}`, {
+      endpoint: "Dot",
+      anchor: "TopLeft",
+      isSource: true,
+      connectionType: "red-connection"
+    })
+  });
 
   // 主張の表示がツリー型になるよう接続線を引く + 主張内にターゲットエンドポイントを設置する
-  jsPlumb.registerConnectionTypes({
-    "red-connection": {
-      paintStyle: {stroke: "red", strokeWidth: 5},
-      hoverPaintStyle: {stroke: "red", strokeWidth: 10}
-    }
-  });
-
   const conclusions = document.querySelectorAll(".conclusion");
   conclusions.forEach( function( conclusion ) {
     const conclusion_id = conclusion.getAttribute("id");

--- a/app/javascript/packs/argument.js
+++ b/app/javascript/packs/argument.js
@@ -1,5 +1,5 @@
-// 主張の表示がツリー型になるよう線を引く
 jsPlumb.ready(function() {
+  // 主張の表示がツリー型になるよう接続線を引く
   const conclusions = document.querySelectorAll(".conclusion");
 
   conclusions.forEach( function( conclusion ) {
@@ -8,7 +8,7 @@ jsPlumb.ready(function() {
 
     reasons_of_conclusion.forEach( function( reason ) {
       const reason_id = reason.getAttribute("id");
-      // 結論 → endponit
+      // 結論 → endpoint 間に接続線を引く
       jsPlumb.connect({
         source: `${conclusion_id}`,
         target: `endpoint_between_${conclusion_id}_and_${reason_id}`,
@@ -19,7 +19,7 @@ jsPlumb.ready(function() {
           ["Arrow", {width: 10, length: 10}]
         ]
       });
-      // endponit → 理由
+      // endpoint → 理由 間に接続線を引く
       jsPlumb.connect({
         source: `endpoint_between_${conclusion_id}_and_${reason_id}`,
         target: `${reason_id}`,
@@ -35,7 +35,7 @@ jsPlumb.ready(function() {
 
       evidences_of_reason.forEach( function( evidence ) {
         const evidence_id = evidence.getAttribute("id");
-        // 理由 → endpoint
+        // 理由 → endpoint 間に接続線を引く
         jsPlumb.connect({
           source: `${reason_id}`,
           target: `endpoint_between_${reason_id}_and_${evidence_id}`,
@@ -46,10 +46,79 @@ jsPlumb.ready(function() {
             ["Arrow", {width: 10, length: 10}]
           ]
         });
-        // endpoint → 証拠
+        // endpoint → 証拠 間に接続線を引く
         jsPlumb.connect({
           source: `endpoint_between_${reason_id}_and_${evidence_id}`,
           target: `${evidence_id}`,
+          anchors: ["Bottom", "Top"],
+          connector: "Straight",
+          endpoint:"Blank",
+          overlays:[
+            ["Arrow", {width: 10, length: 10}]
+          ]
+        });
+      });
+    });
+  });
+
+  // 反論(サンプル)の表示がツリー型になるよう接続線を引く
+  const ref_conclusions = document.querySelectorAll(".ref_conclusion");
+
+  jsPlumb.registerConnectionTypes({
+    "red-connection": {
+      paintStyle: {stroke: "red", strokeWidth: 5},
+      hoverPaintStyle: {stroke: "red", strokeWidth: 10}
+    }
+  });
+
+  ref_conclusions.forEach( function( ref_conclusion ) {
+    const ref_conclusion_id = ref_conclusion.getAttribute("id");
+    const ref_reasons_of_ref_conclusion = document.querySelectorAll(`.ref_reason_of_${ref_conclusion_id}`);
+
+    ref_reasons_of_ref_conclusion.forEach( function( ref_reason ) {
+      const ref_reason_id = ref_reason.getAttribute("id");
+
+      jsPlumb.connect({
+        source: `${ref_conclusion_id}`,
+        target: `endpoint_between_${ref_conclusion_id}_and_${ref_reason_id}`,
+        anchors: ["Bottom", "Top"],
+        connector: "Straight",
+        endpoint:"Blank",
+        overlays:[
+          ["Arrow", {width: 10, length: 10}]
+        ]
+      });
+
+      jsPlumb.connect({
+        source: `endpoint_between_${ref_conclusion_id}_and_${ref_reason_id}`,
+        target: `${ref_reason_id}`,
+        anchors: ["Bottom", "Top"],
+        connector: "Straight",
+        endpoint:"Blank",
+        overlays:[
+          ["Arrow", {width: 10, length: 10}]
+        ]
+      });
+
+      const ref_evidences_of_ref_reason = document.querySelectorAll(`.ref_evidence_of_${ref_reason_id}`);
+
+      ref_evidences_of_ref_reason.forEach( function( ref_evidence ) {
+        const ref_evidence_id = ref_evidence.getAttribute("id");
+
+        jsPlumb.connect({
+          source: `${ref_reason_id}`,
+          target: `endpoint_between_${ref_reason_id}_and_${ref_evidence_id}`,
+          anchors: ["Bottom", "Top"],
+          connector: "Straight",
+          endpoint:"Blank",
+          overlays:[
+            ["Arrow", {width: 10, length: 10}]
+          ]
+        });
+
+        jsPlumb.connect({
+          source: `endpoint_between_${ref_reason_id}_and_${ref_evidence_id}`,
+          target: `${ref_evidence_id}`,
           anchors: ["Bottom", "Top"],
           connector: "Straight",
           endpoint:"Blank",

--- a/app/javascript/packs/argument.js
+++ b/app/javascript/packs/argument.js
@@ -1,17 +1,63 @@
-const conclusions = document.querySelectorAll(".conclusion");
-conclusions.forEach( function( conclusion, conclusion_i ) {
-  const endpoints_between_conclusion_and_reason = document.querySelectorAll(`.endpoint_between_conclusion${conclusion_i}_and_reason`);
-  const reasons_of_conclusion = document.querySelectorAll(`.reason_of_conclusion${conclusion_i}`);
+// 主張の表示がツリー型になるよう線を引く
+jsPlumb.ready(function() {
+  const conclusions = document.querySelectorAll(".conclusion");
 
-  reasons_of_conclusion.forEach( function( reason, reason_i ) {
-    new LeaderLine(conclusion, endpoints_between_conclusion_and_reason[reason_i], {startSocket: "bottom", endSocket: "top", path: "straight"});
-    new LeaderLine(endpoints_between_conclusion_and_reason[reason_i], reason, {startSocket: "bottom", endSocket: "top", path: "straight"});
-    const endpoints_between_reason_of_conclusion_and_evidence = document.querySelectorAll(`.endpoint_between_reason${reason_i}_of_conclusion${conclusion_i}_and_evidence`);
-    const evidences_of_reason_of_conclusion = document.querySelectorAll(`.evidence_of_reason${reason_i}_of_conclusion${conclusion_i}`);
+  conclusions.forEach( function( conclusion ) {
+    const conclusion_id = conclusion.getAttribute("id");
+    const reasons_of_conclusion = document.querySelectorAll(`.reason_of_${conclusion_id}`);
 
-    evidences_of_reason_of_conclusion.forEach( function( evidence, evidence_i ) {
-      new LeaderLine(reason, endpoints_between_reason_of_conclusion_and_evidence[evidence_i], {startSocket: "bottom", endSocket: "top", path: "straight"});
-      new LeaderLine(endpoints_between_reason_of_conclusion_and_evidence[evidence_i], evidence, {startSocket: "bottom", endSocket: "top", path: "straight"});
+    reasons_of_conclusion.forEach( function( reason ) {
+      const reason_id = reason.getAttribute("id");
+      // 結論 → endponit
+      jsPlumb.connect({
+        source: `${conclusion_id}`,
+        target: `endpoint_between_${conclusion_id}_and_${reason_id}`,
+        anchors: ["Bottom", "Top"],
+        connector: "Straight",
+        endpoint:"Blank",
+        overlays:[
+          ["Arrow", {width: 10, length: 10}]
+        ]
+      });
+      // endponit → 理由
+      jsPlumb.connect({
+        source: `endpoint_between_${conclusion_id}_and_${reason_id}`,
+        target: `${reason_id}`,
+        anchors: ["Bottom", "Top"],
+        connector: "Straight",
+        endpoint:"Blank",
+        overlays:[
+          ["Arrow", {width: 10, length: 10}]
+        ]
+      });
+
+      const evidences_of_reason = document.querySelectorAll(`.evidence_of_${reason_id}`);
+
+      evidences_of_reason.forEach( function( evidence ) {
+        const evidence_id = evidence.getAttribute("id");
+        // 理由 → endpoint
+        jsPlumb.connect({
+          source: `${reason_id}`,
+          target: `endpoint_between_${reason_id}_and_${evidence_id}`,
+          anchors: ["Bottom", "Top"],
+          connector: "Straight",
+          endpoint:"Blank",
+          overlays:[
+            ["Arrow", {width: 10, length: 10}]
+          ]
+        });
+        // endpoint → 証拠
+        jsPlumb.connect({
+          source: `endpoint_between_${reason_id}_and_${evidence_id}`,
+          target: `${evidence_id}`,
+          anchors: ["Bottom", "Top"],
+          connector: "Straight",
+          endpoint:"Blank",
+          overlays:[
+            ["Arrow", {width: 10, length: 10}]
+          ]
+        });
+      });
     });
   });
 });

--- a/app/javascript/packs/argument.js
+++ b/app/javascript/packs/argument.js
@@ -2,19 +2,21 @@ jsPlumb.ready(function() {
   jsPlumb.setContainer("exchange_of_opinions");
   // 主張をドラッグ可能にし､リロード後も主張の位置が再現されるようにする
   const all_arguments = document.querySelectorAll(".argument");
-
   all_arguments.forEach( function( argument ) {
     const argument_id = argument.getAttribute("id");
+
     // 主張をドラッグ可能にする
     jsPlumb.draggable(`${argument_id}`, {
       stop: function(event) {
         savePositions();
       }
     });
+
     // 主張のドラッグ終了後の位置をローカルストレージに保存する関数
     function savePositions() {
       localStorage.setItem(`${argument_id}_position`, JSON.stringify($(`#${argument_id}`).position()));
     }
+
     // ローカルストレージに保存された主張の位置を復元する
     const argument_position = JSON.parse(localStorage.getItem(`${argument_id}_position`));
     if (argument_position) {
@@ -24,7 +26,6 @@ jsPlumb.ready(function() {
 
   // 反論をドラッグ可能にし､リロード後も反論の位置が再現されるようにする
   const all_refutations = document.querySelectorAll(".refutation");
-
   all_refutations.forEach( function( refutation ) {
     const refutation_id = refutation.getAttribute("id");
 
@@ -45,15 +46,36 @@ jsPlumb.ready(function() {
   });
 
 
-  // 主張の表示がツリー型になるよう接続線を引く
-  const conclusions = document.querySelectorAll(".conclusion");
+  // 主張の表示がツリー型になるよう接続線を引く + 主張内にターゲットエンドポイントを設置する
+  jsPlumb.registerConnectionTypes({
+    "red-connection": {
+      paintStyle: {stroke: "red", strokeWidth: 5},
+      hoverPaintStyle: {stroke: "red", strokeWidth: 10}
+    }
+  });
 
+  const conclusions = document.querySelectorAll(".conclusion");
   conclusions.forEach( function( conclusion ) {
     const conclusion_id = conclusion.getAttribute("id");
-    const reasons_of_conclusion = document.querySelectorAll(`.reason_of_${conclusion_id}`);
 
+    // 結論の左右中央にターゲットエンドポイントを設置する
+    jsPlumb.addEndpoint(`${conclusion_id}`, {
+      endpoint: "Dot",
+      anchor: "RightMiddle",
+      isTarget: true,
+      connectionType: "red-connection"
+    })
+    jsPlumb.addEndpoint(`${conclusion_id}`, {
+      endpoint: "Dot",
+      anchor: "LeftMiddle",
+      isTarget: true,
+      connectionType: "red-connection"
+    })
+
+    const reasons_of_conclusion = document.querySelectorAll(`.reason_of_${conclusion_id}`);
     reasons_of_conclusion.forEach( function( reason ) {
       const reason_id = reason.getAttribute("id");
+
       // 結論 → endpoint 間に接続線を引く
       jsPlumb.connect({
         source: `${conclusion_id}`,
@@ -65,6 +87,15 @@ jsPlumb.ready(function() {
           ["Arrow", {width: 10, length: 10}]
         ]
       });
+
+      // endpointの真ん中にターゲットエンドポイントを設置する
+      jsPlumb.addEndpoint(`endpoint_between_${conclusion_id}_and_${reason_id}`, {
+        endpoint: "Dot",
+        anchor: "Center",
+        isTarget: true,
+        connectionType: "red-connection"
+      })
+
       // endpoint → 理由 間に接続線を引く
       jsPlumb.connect({
         source: `endpoint_between_${conclusion_id}_and_${reason_id}`,
@@ -77,8 +108,21 @@ jsPlumb.ready(function() {
         ]
       });
 
-      const evidences_of_reason = document.querySelectorAll(`.evidence_of_${reason_id}`);
+      // 理由の左右中央にターゲットエンドポイントを設置する
+      jsPlumb.addEndpoint(`${reason_id}`, {
+        endpoint: "Dot",
+        anchor: "RightMiddle",
+        isTarget: true,
+        connectionType: "red-connection"
+      })
+      jsPlumb.addEndpoint(`${reason_id}`, {
+        endpoint: "Dot",
+        anchor: "LeftMiddle",
+        isTarget: true,
+        connectionType: "red-connection"
+      })
 
+      const evidences_of_reason = document.querySelectorAll(`.evidence_of_${reason_id}`);
       evidences_of_reason.forEach( function( evidence ) {
         const evidence_id = evidence.getAttribute("id");
         // 理由 → endpoint 間に接続線を引く
@@ -92,6 +136,15 @@ jsPlumb.ready(function() {
             ["Arrow", {width: 10, length: 10}]
           ]
         });
+
+        // endpointの真ん中にターゲットエンドポイントを設置する
+        jsPlumb.addEndpoint(`endpoint_between_${reason_id}_and_${evidence_id}`, {
+          endpoint: "Dot",
+          anchor: "Center",
+          isTarget: true,
+          connectionType: "red-connection"
+        })
+
         // endpoint → 証拠 間に接続線を引く
         jsPlumb.connect({
           source: `endpoint_between_${reason_id}_and_${evidence_id}`,
@@ -103,24 +156,43 @@ jsPlumb.ready(function() {
             ["Arrow", {width: 10, length: 10}]
           ]
         });
+
+        // 証拠の左右中央にターゲットエンドポイントを設置する
+        jsPlumb.addEndpoint(`${evidence_id}`, {
+          endpoint: "Dot",
+          anchor: "RightMiddle",
+          isTarget: true,
+          connectionType: "red-connection"
+        })
+        jsPlumb.addEndpoint(`${evidence_id}`, {
+          endpoint: "Dot",
+          anchor: "LeftMiddle",
+          isTarget: true,
+          connectionType: "red-connection"
+        })
       });
     });
   });
 
-  // 反論(サンプル)の表示がツリー型になるよう接続線を引く
+  // 反論(サンプル)の表示がツリー型になるよう接続線を引く + 反論内にターゲットエンドポイントを設置する
   const ref_conclusions = document.querySelectorAll(".ref_conclusion");
-
-  jsPlumb.registerConnectionTypes({
-    "red-connection": {
-      paintStyle: {stroke: "red", strokeWidth: 5},
-      hoverPaintStyle: {stroke: "red", strokeWidth: 10}
-    }
-  });
-
   ref_conclusions.forEach( function( ref_conclusion ) {
     const ref_conclusion_id = ref_conclusion.getAttribute("id");
-    const ref_reasons_of_ref_conclusion = document.querySelectorAll(`.ref_reason_of_${ref_conclusion_id}`);
 
+    jsPlumb.addEndpoint(`${ref_conclusion_id}`, {
+      endpoint: "Dot",
+      anchor: "RightMiddle",
+      isTarget: true,
+      connectionType: "red-connection"
+    })
+    jsPlumb.addEndpoint(`${ref_conclusion_id}`, {
+      endpoint: "Dot",
+      anchor: "LeftMiddle",
+      isTarget: true,
+      connectionType: "red-connection"
+    })
+
+    const ref_reasons_of_ref_conclusion = document.querySelectorAll(`.ref_reason_of_${ref_conclusion_id}`);
     ref_reasons_of_ref_conclusion.forEach( function( ref_reason ) {
       const ref_reason_id = ref_reason.getAttribute("id");
 
@@ -135,6 +207,13 @@ jsPlumb.ready(function() {
         ]
       });
 
+      jsPlumb.addEndpoint(`endpoint_between_${ref_conclusion_id}_and_${ref_reason_id}`, {
+        endpoint: "Dot",
+        anchor: "Center",
+        isTarget: true,
+        connectionType: "red-connection",
+      })
+
       jsPlumb.connect({
         source: `endpoint_between_${ref_conclusion_id}_and_${ref_reason_id}`,
         target: `${ref_reason_id}`,
@@ -145,6 +224,19 @@ jsPlumb.ready(function() {
           ["Arrow", {width: 10, length: 10}]
         ]
       });
+
+      jsPlumb.addEndpoint(`${ref_reason_id}`, {
+        endpoint: "Dot",
+        anchor: "RightMiddle",
+        isTarget: true,
+        connectionType: "red-connection"
+      })
+      jsPlumb.addEndpoint(`${ref_reason_id}`, {
+        endpoint: "Dot",
+        anchor: "LeftMiddle",
+        isTarget: true,
+        connectionType: "red-connection"
+      })
 
       const ref_evidences_of_ref_reason = document.querySelectorAll(`.ref_evidence_of_${ref_reason_id}`);
 
@@ -162,6 +254,13 @@ jsPlumb.ready(function() {
           ]
         });
 
+        jsPlumb.addEndpoint(`endpoint_between_${ref_reason_id}_and_${ref_evidence_id}`, {
+          endpoint: "Dot",
+          anchor: "Center",
+          isTarget: true,
+          connectionType: "red-connection"
+        })
+
         jsPlumb.connect({
           source: `endpoint_between_${ref_reason_id}_and_${ref_evidence_id}`,
           target: `${ref_evidence_id}`,
@@ -172,6 +271,19 @@ jsPlumb.ready(function() {
             ["Arrow", {width: 10, length: 10}]
           ]
         });
+
+        jsPlumb.addEndpoint(`${ref_evidence_id}`, {
+          endpoint: "Dot",
+          anchor: "RightMiddle",
+          isTarget: true,
+          connectionType: "red-connection"
+        })
+        jsPlumb.addEndpoint(`${ref_evidence_id}`, {
+          endpoint: "Dot",
+          anchor: "LeftMiddle",
+          isTarget: true,
+          connectionType: "red-connection"
+        })
       });
     });
   });

--- a/app/javascript/packs/argument.js
+++ b/app/javascript/packs/argument.js
@@ -1,4 +1,50 @@
 jsPlumb.ready(function() {
+  jsPlumb.setContainer("exchange_of_opinions");
+  // 主張をドラッグ可能にし､リロード後も主張の位置が再現されるようにする
+  const all_arguments = document.querySelectorAll(".argument");
+
+  all_arguments.forEach( function( argument ) {
+    const argument_id = argument.getAttribute("id");
+    // 主張をドラッグ可能にする
+    jsPlumb.draggable(`${argument_id}`, {
+      stop: function(event) {
+        savePositions();
+      }
+    });
+    // 主張のドラッグ終了後の位置をローカルストレージに保存する関数
+    function savePositions() {
+      localStorage.setItem(`${argument_id}_position`, JSON.stringify($(`#${argument_id}`).position()));
+    }
+    // ローカルストレージに保存された主張の位置を復元する
+    const argument_position = JSON.parse(localStorage.getItem(`${argument_id}_position`));
+    if (argument_position) {
+      $(`#${argument_id}`).css({left: argument_position.left + "px", top: argument_position.top + "px"});
+    }
+  });
+
+  // 反論をドラッグ可能にし､リロード後も反論の位置が再現されるようにする
+  const all_refutations = document.querySelectorAll(".refutation");
+
+  all_refutations.forEach( function( refutation ) {
+    const refutation_id = refutation.getAttribute("id");
+
+    jsPlumb.draggable(`${refutation_id}`, {
+      stop: function(event) {
+        savePositions();
+      }
+    });
+
+    function savePositions() {
+      localStorage.setItem(`${refutation_id}_position`, JSON.stringify($(`#${refutation_id}`).position()));
+    }
+
+    const refutation_position = JSON.parse(localStorage.getItem(`${refutation_id}_position`));
+    if (refutation_position) {
+      $(`#${refutation_id}`).css({left: refutation_position.left + "px", top: refutation_position.top + "px"});
+    }
+  });
+
+
   // 主張の表示がツリー型になるよう接続線を引く
   const conclusions = document.querySelectorAll(".conclusion");
 

--- a/app/javascript/packs/argument.js
+++ b/app/javascript/packs/argument.js
@@ -294,4 +294,23 @@ jsPlumb.ready(function() {
       });
     });
   });
+
+  // 接続線が右クリックされたとき､｢削除ボタン｣を表示する
+  jsPlumb.bind("contextmenu", function (component, event) {
+    if (component.hasClass("jtk-connector")) {
+      event.preventDefault();
+      window.selectedConnection = component;
+      $("<div class='custom-menu'><button class='delete-connection'>Delete connection</button></div>")
+        .appendTo("body")
+        .css({top: event.pageY + "px", left: event.pageX + "px"});
+    }
+  });
+  // 削除ボタンが左クリックされたとき､接続線を削除する
+  $("body").on("click", ".delete-connection", function(event) {
+    jsPlumb.deleteConnection(window.selectedConnection);
+  });
+  // 削除ボタンが左クリックされたとき､｢削除ボタン｣を削除する
+  $(document).on("click", function(event) {
+    $("div.custom-menu").remove();
+  });
 });

--- a/app/javascript/packs/argument.js
+++ b/app/javascript/packs/argument.js
@@ -1,0 +1,17 @@
+const conclusions = document.querySelectorAll(".conclusion");
+conclusions.forEach( function( conclusion, conclusion_i ) {
+  const endpoints_between_conclusion_and_reason = document.querySelectorAll(`.endpoint_between_conclusion${conclusion_i}_and_reason`);
+  const reasons_of_conclusion = document.querySelectorAll(`.reason_of_conclusion${conclusion_i}`);
+
+  reasons_of_conclusion.forEach( function( reason, reason_i ) {
+    new LeaderLine(conclusion, endpoints_between_conclusion_and_reason[reason_i], {startSocket: "bottom", endSocket: "top", path: "straight"});
+    new LeaderLine(endpoints_between_conclusion_and_reason[reason_i], reason, {startSocket: "bottom", endSocket: "top", path: "straight"});
+    const endpoints_between_reason_of_conclusion_and_evidence = document.querySelectorAll(`.endpoint_between_reason${reason_i}_of_conclusion${conclusion_i}_and_evidence`);
+    const evidences_of_reason_of_conclusion = document.querySelectorAll(`.evidence_of_reason${reason_i}_of_conclusion${conclusion_i}`);
+
+    evidences_of_reason_of_conclusion.forEach( function( evidence, evidence_i ) {
+      new LeaderLine(reason, endpoints_between_reason_of_conclusion_and_evidence[evidence_i], {startSocket: "bottom", endSocket: "top", path: "straight"});
+      new LeaderLine(endpoints_between_reason_of_conclusion_and_evidence[evidence_i], evidence, {startSocket: "bottom", endSocket: "top", path: "straight"});
+    });
+  });
+});

--- a/app/views/agenda_boards/show.html.erb
+++ b/app/views/agenda_boards/show.html.erb
@@ -60,11 +60,11 @@
           <div class="ref_conclusion box" id="ref_conclusion0">
             <h3>反論</h3>
             <div class="inner">
-              結論と理由の繋がりが薄い
+              理由詳細の部分に誤りがある｡
             </div>
             <h3>反論詳細</h3>
             <div class="inner">
-              体内時計と噛み合っていないことは､健康に悪いことの十分条件ではない
+              提示された､｢体内時計的に最適な起床時間｣は誤りである｡
             </div>
           </div>
 
@@ -74,11 +74,11 @@
               <div class="ref_reason box ref_reason_of_ref_conclusion0" id="ref_reason0_of_ref_conclusion0">
                 <h3>理由</h3>
                 <div class="inner">
-                  体内時計が噛み合っていなくても､健康なヒトはたくさんいる
+                  体内時計は同年齢間においても個人差があり､一律ではないから
                 </div>
                 <h3>理由詳細</h3>
                 <div class="inner">
-                  夜職のバイト先の店長とかめっちゃ元気
+                  0時過ぎに寝て8時頃に起きるのが自然のリズムである人が最も多く、一方で、1:30以降に寝て9:30以降に起きるような夜型の人や、逆に22:30頃前に寝て6:30以前に自然に起きるような朝型の人もいる｡
                 </div>
               </div>
 
@@ -88,11 +88,11 @@
                   <div class="ref_evidence box ref_evidence_of_ref_reason0_of_ref_conclusion0" id="ref_evidence0_of_ref_reason0_of_ref_conclusion0">
                     <h3>証拠</h3>
                     <div class="inner">
-                      俺のバイト先
+                      8155名のMSFsc(睡眠負債がない状態において、自然に眠り自然に起きる時の、睡眠時間帯の中間時刻)調査結果
                     </div>
                     <h3>証拠詳細</h3>
                     <div class="inner">
-                      bar ホワイトゴース
+                      https://team.tokyo-med.ac.jp/omh/news/202203_chronotype/
                     </div>
                   </div>
                 </div>
@@ -108,11 +108,11 @@
           <div class="ref_conclusion box" id="ref_conclusion1">
             <h3>反論</h3>
             <div class="inner">
-              証拠が主観的で不確かである
+              証拠が理由に適するものではない
             </div>
             <h3>反論詳細</h3>
             <div class="inner">
-              個人1人の健康状態は証拠として弱すぎる
+              特になし
             </div>
           </div>
 
@@ -122,11 +122,11 @@
               <div class="ref_reason box ref_reason_of_ref_conclusion1" id="ref_reason0_of_ref_conclusion1">
                 <h3>理由</h3>
                 <div class="inner">
-                  その店長が元気 → 体内時計が噛み合って居ないヒトはみんな健康 とはならない
+                  証拠にあげている調査は､同年齢を対象としたものではないから｡
                 </div>
                 <h3>理由詳細</h3>
                 <div class="inner">
-                  特になし
+                  提示された調査は､様々な年齢の人々(平均年齢は36.7歳)を対象にしたものなので､｢体内時計は同年齢間においても個人差がある｣ということの証拠として適当ではない
                 </div>
               </div>
 

--- a/app/views/agenda_boards/show.html.erb
+++ b/app/views/agenda_boards/show.html.erb
@@ -1,6 +1,6 @@
 <div class="agenda">
   <h1><%= @agenda_board.agenda %></h1>
-    <% @conclusions.each do |conclusion| %>
+    <% @conclusions.each_with_index do |conclusion, conclusion_i| %>
       <h3 class="claimant_name"><%= current_user.name %>さんの主張</h3>
       <div class="argument">
         <div class="conclusion box">
@@ -15,10 +15,10 @@
         </div>
 
         <div class="bases">
-          <% conclusion.reasons.each do |reason| %>
+          <% conclusion.reasons.each_with_index do |reason, reason_i| %>
             <div class="basis">
-              <div class="endpoint"></div>
-              <div class="reason box">
+              <div class="endpoint endpoint_between_conclusion<%= conclusion_i %>_and_reason"></div>
+              <div class="reason box reason_of_conclusion<%= conclusion_i %>">
                 <h3>理由</h3>
                 <div class="inner">
                   <%= reason.reason_summary %>
@@ -30,10 +30,10 @@
               </div>
 
               <div class="evidences">
-                <% reason.evidences.each do |evidence| %>
+                <% reason.evidences.each_with_index do |evidence| %>
                   <div class="evidence">
-                    <div class="endpoint"></div>
-                    <div class="evidence box">
+                    <div class="endpoint endpoint_between_reason<%= reason_i %>_of_conclusion<%= conclusion_i %>_and_evidence"></div>
+                    <div class="evidence box evidence_of_reason<%= reason_i %>_of_conclusion<%= conclusion_i %>">
                       <h3>証拠</h3>
                       <div class="inner">
                         <%= evidence.evidence_summary %>
@@ -53,3 +53,5 @@
     <% end %>
   <%= button_to "新規主張作成", new_argument_path, method: :get, params: {agenda_board_id: @agenda_board.id, agenda_board_agenda: @agenda_board.agenda} %>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/leader-line@1.0.1/leader-line.min.js"></script>
+<%= javascript_pack_tag 'argument' %>

--- a/app/views/agenda_boards/show.html.erb
+++ b/app/views/agenda_boards/show.html.erb
@@ -1,9 +1,9 @@
 <div class="agenda">
   <h1><%= @agenda_board.agenda %></h1>
-    <% @conclusions.each_with_index do |conclusion, conclusion_i| %>
+    <% @conclusions.each_with_index do |conclusion, c_i| %>
       <h3 class="claimant_name"><%= current_user.name %>さんの主張</h3>
       <div class="argument">
-        <div class="conclusion box">
+        <div class="conclusion box" id="conclusion<%= c_i %>">
           <h3>結論</h3>
           <div class="inner">
             <%= conclusion.conclusion_summary %>
@@ -15,10 +15,10 @@
         </div>
 
         <div class="bases">
-          <% conclusion.reasons.each_with_index do |reason, reason_i| %>
+          <% conclusion.reasons.each_with_index do |reason, r_i| %>
             <div class="basis">
-              <div class="endpoint endpoint_between_conclusion<%= conclusion_i %>_and_reason"></div>
-              <div class="reason box reason_of_conclusion<%= conclusion_i %>">
+              <div class="endpoint endpoint_between_conclusion<%= c_i %>_and_reason" id="endpoint_between_conclusion<%= c_i %>_and_reason<%= r_i %>_of_conclusion<%= c_i %>"></div>
+              <div class="reason box reason_of_conclusion<%= c_i %>" id="reason<%= r_i %>_of_conclusion<%= c_i %>">
                 <h3>理由</h3>
                 <div class="inner">
                   <%= reason.reason_summary %>
@@ -30,10 +30,10 @@
               </div>
 
               <div class="evidences">
-                <% reason.evidences.each_with_index do |evidence| %>
+                <% reason.evidences.each_with_index do |evidence, e_i| %>
                   <div class="evidence">
-                    <div class="endpoint endpoint_between_reason<%= reason_i %>_of_conclusion<%= conclusion_i %>_and_evidence"></div>
-                    <div class="evidence box evidence_of_reason<%= reason_i %>_of_conclusion<%= conclusion_i %>">
+                    <div class="endpoint endpoint_between_reason<%= r_i %>_of_conclusion<%= c_i %>_and_evidence" id="endpoint_between_reason<%= r_i %>_of_conclusion<%= c_i %>_and_evidence<%= e_i %>_of_reason<%= r_i %>_of_conclusion<%= c_i %>"></div>
+                    <div class="evidence box evidence_of_reason<%= r_i %>_of_conclusion<%= c_i %>" id="evidence<%= e_i %>_of_reason<%= r_i %>_of_conclusion<%= c_i %>">
                       <h3>証拠</h3>
                       <div class="inner">
                         <%= evidence.evidence_summary %>
@@ -53,5 +53,9 @@
     <% end %>
   <%= button_to "新規主張作成", new_argument_path, method: :get, params: {agenda_board_id: @agenda_board.id, agenda_board_agenda: @agenda_board.agenda} %>
 </div>
-<script src="https://cdn.jsdelivr.net/npm/leader-line@1.0.1/leader-line.min.js"></script>
+<script
+src="https://code.jquery.com/jquery-3.5.1.min.js"
+integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
+crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jsPlumb/2.14.3/js/jsplumb.min.js"></script>
 <%= javascript_pack_tag 'argument' %>

--- a/app/views/agenda_boards/show.html.erb
+++ b/app/views/agenda_boards/show.html.erb
@@ -1,56 +1,155 @@
 <div class="agenda">
   <h1><%= @agenda_board.agenda %></h1>
+    <div id="exchange_of_opinions">
     <% @conclusions.each_with_index do |conclusion, c_i| %>
-      <h3 class="claimant_name"><%= current_user.name %>さんの主張</h3>
-      <div class="argument">
-        <div class="conclusion box" id="conclusion<%= c_i %>">
-          <h3>結論</h3>
-          <div class="inner">
-            <%= conclusion.conclusion_summary %>
+      <div class="argument" id="argument<%= c_i %>">
+        <h3 class="claimant_name"><%= current_user.name %>さんの主張</h3>
+        <div class="tree_structure">
+          <div class="conclusion box" id="conclusion<%= c_i %>">
+            <h3>結論</h3>
+            <div class="inner">
+              <%= conclusion.conclusion_summary %>
+            </div>
+            <h3>結論詳細</h3>
+            <div class="inner">
+              <%= conclusion.conclusion_detail %>
+            </div>
           </div>
-          <h3>結論詳細</h3>
-          <div class="inner">
-            <%= conclusion.conclusion_detail %>
+
+          <div class="bases">
+            <% conclusion.reasons.each_with_index do |reason, r_i| %>
+              <div class="basis">
+                <div class="endpoint endpoint_between_conclusion<%= c_i %>_and_reason" id="endpoint_between_conclusion<%= c_i %>_and_reason<%= r_i %>_of_conclusion<%= c_i %>"></div>
+                <div class="reason box reason_of_conclusion<%= c_i %>" id="reason<%= r_i %>_of_conclusion<%= c_i %>">
+                  <h3>理由</h3>
+                  <div class="inner">
+                    <%= reason.reason_summary %>
+                  </div>
+                  <h3>理由詳細</h3>
+                  <div class="inner">
+                    <%= reason.reason_detail %>
+                  </div>
+                </div>
+
+                <div class="evidences">
+                  <% reason.evidences.each_with_index do |evidence, e_i| %>
+                    <div class="evidence">
+                      <div class="endpoint endpoint_between_reason<%= r_i %>_of_conclusion<%= c_i %>_and_evidence" id="endpoint_between_reason<%= r_i %>_of_conclusion<%= c_i %>_and_evidence<%= e_i %>_of_reason<%= r_i %>_of_conclusion<%= c_i %>"></div>
+                      <div class="evidence box evidence_of_reason<%= r_i %>_of_conclusion<%= c_i %>" id="evidence<%= e_i %>_of_reason<%= r_i %>_of_conclusion<%= c_i %>">
+                        <h3>証拠</h3>
+                        <div class="inner">
+                          <%= evidence.evidence_summary %>
+                        </div>
+                        <h3>証拠詳細</h3>
+                        <div class="inner">
+                          <%= evidence.evidence_detail %>
+                        </div>
+                      </div>
+                    </div>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
           </div>
         </div>
+      </div>
+    <% end %>
+      <div class="refutation" id="refutation0">
+        <h3 class="claimant_name">反論0</h3>
+        <div class="tree_structure">
+          <div class="ref_conclusion box" id="ref_conclusion0">
+            <h3>反論</h3>
+            <div class="inner">
+              結論と理由の繋がりが薄い
+            </div>
+            <h3>反論詳細</h3>
+            <div class="inner">
+              体内時計と噛み合っていないことは､健康に悪いことの十分条件ではない
+            </div>
+          </div>
 
-        <div class="bases">
-          <% conclusion.reasons.each_with_index do |reason, r_i| %>
+          <div class="bases">
             <div class="basis">
-              <div class="endpoint endpoint_between_conclusion<%= c_i %>_and_reason" id="endpoint_between_conclusion<%= c_i %>_and_reason<%= r_i %>_of_conclusion<%= c_i %>"></div>
-              <div class="reason box reason_of_conclusion<%= c_i %>" id="reason<%= r_i %>_of_conclusion<%= c_i %>">
+              <div class="endpoint endpoint_between_ref_conclusion0_and_ref_reason" id="endpoint_between_ref_conclusion0_and_ref_reason0_of_ref_conclusion0"></div>
+              <div class="ref_reason box ref_reason_of_ref_conclusion0" id="ref_reason0_of_ref_conclusion0">
                 <h3>理由</h3>
                 <div class="inner">
-                  <%= reason.reason_summary %>
+                  体内時計が噛み合っていなくても､健康なヒトはたくさんいる
                 </div>
                 <h3>理由詳細</h3>
                 <div class="inner">
-                  <%= reason.reason_detail %>
+                  夜職のバイト先の店長とかめっちゃ元気
                 </div>
               </div>
 
               <div class="evidences">
-                <% reason.evidences.each_with_index do |evidence, e_i| %>
-                  <div class="evidence">
-                    <div class="endpoint endpoint_between_reason<%= r_i %>_of_conclusion<%= c_i %>_and_evidence" id="endpoint_between_reason<%= r_i %>_of_conclusion<%= c_i %>_and_evidence<%= e_i %>_of_reason<%= r_i %>_of_conclusion<%= c_i %>"></div>
-                    <div class="evidence box evidence_of_reason<%= r_i %>_of_conclusion<%= c_i %>" id="evidence<%= e_i %>_of_reason<%= r_i %>_of_conclusion<%= c_i %>">
-                      <h3>証拠</h3>
-                      <div class="inner">
-                        <%= evidence.evidence_summary %>
-                      </div>
-                      <h3>証拠詳細</h3>
-                      <div class="inner">
-                        <%= evidence.evidence_detail %>
-                      </div>
+                <div class="ref_evidence">
+                  <div class="endpoint endpoint_between_ref_reason0_of_ref_conclusion0_and_ref_evidence" id="endpoint_between_ref_reason0_of_ref_conclusion0_and_ref_evidence0_of_ref_reason0_of_ref_conclusion0"></div>
+                  <div class="ref_evidence box ref_evidence_of_ref_reason0_of_ref_conclusion0" id="ref_evidence0_of_ref_reason0_of_ref_conclusion0">
+                    <h3>証拠</h3>
+                    <div class="inner">
+                      俺のバイト先
+                    </div>
+                    <h3>証拠詳細</h3>
+                    <div class="inner">
+                      bar ホワイトゴース
                     </div>
                   </div>
-                <% end %>
+                </div>
               </div>
             </div>
-          <% end %>
+          </div>
         </div>
       </div>
-    <% end %>
+
+      <div class="refutation" id="refutation1">
+        <h3 class="claimant_name">反論1</h3>
+        <div class="tree_structure">
+          <div class="ref_conclusion box" id="ref_conclusion1">
+            <h3>反論</h3>
+            <div class="inner">
+              証拠が主観的で不確かである
+            </div>
+            <h3>反論詳細</h3>
+            <div class="inner">
+              個人1人の健康状態は証拠として弱すぎる
+            </div>
+          </div>
+
+          <div class="bases">
+            <div class="basis">
+              <div class="endpoint endpoint_between_ref_conclusion1_and_ref_reason" id="endpoint_between_ref_conclusion1_and_ref_reason0_of_ref_conclusion1"></div>
+              <div class="ref_reason box ref_reason_of_ref_conclusion1" id="ref_reason0_of_ref_conclusion1">
+                <h3>理由</h3>
+                <div class="inner">
+                  その店長が元気 → 体内時計が噛み合って居ないヒトはみんな健康 とはならない
+                </div>
+                <h3>理由詳細</h3>
+                <div class="inner">
+                  特になし
+                </div>
+              </div>
+
+              <div class="evidences">
+                <div class="ref_evidence">
+                  <div class="endpoint endpoint_between_ref_reason0_of_ref_conclusion1_and_ref_evidence" id="endpoint_between_ref_reason0_of_ref_conclusion1_and_ref_evidence0_of_ref_reason0_of_ref_conclusion1"></div>
+                  <div class="ref_evidence box ref_evidence_of_ref_reason0_of_ref_conclusion1" id="ref_evidence0_of_ref_reason0_of_ref_conclusion1">
+                    <h3>証拠</h3>
+                    <div class="inner">
+                      論理性の話であるため､必要なし
+                    </div>
+                    <h3>証拠詳細</h3>
+                    <div class="inner">
+                      特になし
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   <%= button_to "新規主張作成", new_argument_path, method: :get, params: {agenda_board_id: @agenda_board.id, agenda_board_agenda: @agenda_board.agenda} %>
 </div>
 <script

--- a/app/views/agenda_boards/show.html.erb
+++ b/app/views/agenda_boards/show.html.erb
@@ -1,45 +1,55 @@
 <div class="agenda">
   <h1><%= @agenda_board.agenda %></h1>
-  <% @conclusions.each do |conclusion| %>
-    <table>
-      <tr>
-        <th><%= current_user.name %>さんの主張</th>
-      </tr>
-      <tr>
-        <th>結論</th>
-        <td><%= conclusion.conclusion_summary %></td>
-      </tr>
-      <tr>
-        <th>結論詳細</th>
-        <td><%= conclusion.conclusion_detail %></td>
-      </tr>
-    </table>
+    <% @conclusions.each do |conclusion| %>
+      <h3 class="claimant_name"><%= current_user.name %>さんの主張</h3>
+      <div class="argument">
+        <div class="conclusion box">
+          <h3>結論</h3>
+          <div class="inner">
+            <%= conclusion.conclusion_summary %>
+          </div>
+          <h3>結論詳細</h3>
+          <div class="inner">
+            <%= conclusion.conclusion_detail %>
+          </div>
+        </div>
 
-    <% conclusion.reasons.each do |reason| %>
-      <table>
-        <tr>
-          <th>理由</th>
-          <td><%= reason.reason_summary %></td>
-        </tr>
-        <tr>
-          <th>理由詳細</th>
-          <td><%= reason.reason_detail %></td>
-        </tr>
-      </table>
+        <div class="bases">
+          <% conclusion.reasons.each do |reason| %>
+            <div class="basis">
+              <div class="endpoint"></div>
+              <div class="reason box">
+                <h3>理由</h3>
+                <div class="inner">
+                  <%= reason.reason_summary %>
+                </div>
+                <h3>理由詳細</h3>
+                <div class="inner">
+                  <%= reason.reason_detail %>
+                </div>
+              </div>
 
-      <% reason.evidences.each do |evidence| %>
-        <table>
-          <tr>
-            <th>証拠</th>
-            <td><%= evidence.evidence_summary %></td>
-          </tr>
-          <tr>
-            <th>証拠詳細</th>
-            <td><%= evidence.evidence_detail %></td>
-          </tr>
-        </table>
-      <% end %>
+              <div class="evidences">
+                <% reason.evidences.each do |evidence| %>
+                  <div class="evidence">
+                    <div class="endpoint"></div>
+                    <div class="evidence box">
+                      <h3>証拠</h3>
+                      <div class="inner">
+                        <%= evidence.evidence_summary %>
+                      </div>
+                      <h3>証拠詳細</h3>
+                      <div class="inner">
+                        <%= evidence.evidence_detail %>
+                      </div>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
     <% end %>
-  <% end %>
   <%= button_to "新規主張作成", new_argument_path, method: :get, params: {agenda_board_id: @agenda_board.id, agenda_board_agenda: @agenda_board.agenda} %>
 </div>

--- a/app/views/agenda_boards/show.html.erb
+++ b/app/views/agenda_boards/show.html.erb
@@ -3,7 +3,7 @@
     <div id="exchange_of_opinions">
     <% @conclusions.each_with_index do |conclusion, c_i| %>
       <div class="argument" id="argument<%= c_i %>">
-        <h3 class="claimant_name"><%= current_user.name %>さんの主張</h3>
+        <h3 class="type_of_opinion">主張</h3>
         <div class="tree_structure">
           <div class="conclusion box" id="conclusion<%= c_i %>">
             <h3>結論</h3>
@@ -55,7 +55,7 @@
       </div>
     <% end %>
       <div class="refutation" id="refutation0">
-        <h3 class="claimant_name">反論0</h3>
+        <h3 class="type_of_opinion">反論</h3>
         <div class="tree_structure">
           <div class="ref_conclusion box" id="ref_conclusion0">
             <h3>反論</h3>
@@ -103,7 +103,7 @@
       </div>
 
       <div class="refutation" id="refutation1">
-        <h3 class="claimant_name">反論1</h3>
+        <h3 class="type_of_opinion">反論</h3>
         <div class="tree_structure">
           <div class="ref_conclusion box" id="ref_conclusion1">
             <h3>反論</h3>


### PR DESCRIPTION
## 関連するチケット､Issue､プルリクエストのリンク

* #11

## なぜこの変更をするのか

* ユーザーが､議題ボード詳細ページを見た時､以下の3点を一目でわかるようにするため｡
  尚､この機能は本アプリのメイン機能である｡

1. 何(主張? 反論?)が､
2. どこ(上? 下? 右? 左?) にあって､
3. どの部分(結論? 結論と理由のつなぎ目? ..etc)に繋がっているのか

## やったこと
### 主張の見た目について

- 主張の見た目をツリー型に整えた

### 主張の挙動について
- 反論のサンプルを追加した(主張の挙動を確認する上で必要であるため)
- 主張と反論をドラッグ可能にし､ページリロード後も位置が再現されるようにした
- 主張と反論内にターゲットエンドポイントを､反論の左上にソースエンドポイントを設置した
- 接続線を削除する機能を追加した
- ページリロード後もリロード前の接続線の状態が保持されるようにした

## やらないこと

* 議題ボード詳細ページのjsPlumbを使用した処理に関するシステムスペックの実装
→ 実装の仕方が分かり次第､実装する｡

## 変更内容(議題ボード詳細ページ)
### before
![スクリーンショット 2023-05-07 10 10 23](https://user-images.githubusercontent.com/111355072/236652721-17159fb2-0834-44a6-8f01-a6f88e3dbb83.png)

### after
### 1  反論のサンプルが追加されていることに加え､主張の表示がツリー型に整えられている｡
![スクリーンショット 2023-05-07 11 25 51](https://user-images.githubusercontent.com/111355072/236654441-e3a46d4e-5eef-4d12-901f-c0ffdd50d616.png)
### 2  主張と反論がドラッグ可能になっており､ ページリロード後も位置が再現される｡

https://user-images.githubusercontent.com/111355072/236654400-cb92794a-90ec-4394-98df-bc3bf1ca926c.mov



### 3  主張と反論内にターゲットエンドポイント､反論の左上にソースエンドポイントを設置されていて､ソースエンドポイントからターゲットエンドポイントに向けて赤色の接続線が引ける｡

https://user-images.githubusercontent.com/111355072/236654527-bd3f24ff-6fb1-4210-8e4b-b6008859dbc4.mov

### 4  赤い接続線上で右クリックすると､｢Delate connection｣ボタンが表示され､それを右クリックすると､接続線を削除することができる｡

https://user-images.githubusercontent.com/111355072/236654614-5824e86f-cc92-4838-ba5d-198aeb224cc1.mov

### 5  ページリロード後もリロード前の接続線の状態を保持することができる

https://user-images.githubusercontent.com/111355072/236654845-3d95b27a-9864-438d-b963-6735af002ece.mov


## できるようになること（ユーザ目線）
1. 主張と反論の､結論､理由､証拠部分が一目でわかる｡
2. 主張と反論をドラッグし､好きな場所における｡ページリロード後もその場所が保持される｡
3. 反論の左上にあるソースエンドポイントから､主張・反論内にあるターゲットエンドポイントに赤色の接続線を引くことで､
   どの部分に対する反論なのかを明示することができる｡
4. 誤った接続線を引いてしまったときに､削除することができる｡
5. ページリロード後もリロード前の接続線の状態を保持することができる

## できなくなること（ユーザ目線）

* 無し

## 動作確認
* 本番環境のHerokuアプリ上にて､手動で以下の動作確認を行ったところ､すべて問題なく動作した｡

1. - [x] 主張と反論の見た目がツリー型に表示されているか｡
2. - [x] 主張と反論がドラッグ可能であり､ページリロード後も位置が再現されるか｡
3. - [x] 主張と反論内にターゲットエンドポイントが､反論の左上にソースエンドポイントが設置されているか｡
4. - [x] 接続線を削除する機能が正常に動作しているか｡
5. - [x] ページリロード後もリロード前の接続線の状態が保持されているか｡

## その他

### 参考サイト
jsplumbのtutorial動画
https://www.cdnpkg.com/jsPlumb

jsplumb community editionの公式ドキュメント
https://docs.jsplumbtoolkit.com/community/6.x/

jsplumbのcdnのurlのコピペ元
https://www.cdnpkg.com/jsPlumb
