### PR TITLE
既存の主張や反論に新規反論を作成する機能を実装する

### DIFF
--- a/app/assets/stylesheets/agenda_boards.scss
+++ b/app/assets/stylesheets/agenda_boards.scss
@@ -29,7 +29,7 @@
   display: flex;
 }
 
-.reason {
+.reason, .ref_reason {
   margin: 0 auto;
 }
 
@@ -37,7 +37,7 @@
   display: flex;
 }
 
-.evidence {
+.evidence, .ref_evidence {
   margin: 0 10px;
 }
 

--- a/app/assets/stylesheets/agenda_boards.scss
+++ b/app/assets/stylesheets/agenda_boards.scss
@@ -1,5 +1,14 @@
 // 主張と反論のレイアウト
-.type_of_opinion {
+.argument_title {
+  background: #CC99CC;
+  color: #FFF;
+  margin: 0;
+  display:inline-block;
+  padding: .3em .5em;
+  border-radius: 10px 10px 0 0;
+}
+
+.refutation_title {
   background: #0094D6;
   color: #FFF;
   margin: 0;
@@ -9,6 +18,12 @@
 }
 
 .tree_structure {
+  border: 2px solid #CC99CC;
+  padding: 10px;
+  width: fit-content;
+}
+
+.ref_tree_structure {
   border: 2px solid #0094D6;
   padding: 10px;
   width: fit-content;
@@ -19,7 +34,7 @@
 }
 
 .endpoint {
-  background-color: aquamarine;
+  // background-color: aquamarine;
   width: 20px;
   height: 20px;
   margin: 40px auto;
@@ -45,12 +60,28 @@
   padding: .5em;
 }
 
+.ref_box .inner {
+  padding: .5em;
+}
+
 .box {
+  border: 2px solid #CC99CC;
+  width: 200px;
+}
+
+.ref_box {
   border: 2px solid #0094D6;
   width: 200px;
 }
 
 .box h3 {
+  background: #CC99CC;
+  color: #FFF;
+  text-align: center;
+  margin: 0;
+}
+
+.ref_box h3 {
   background: #0094D6;
   color: #FFF;
   text-align: center;

--- a/app/assets/stylesheets/refutations.scss
+++ b/app/assets/stylesheets/refutations.scss
@@ -1,0 +1,7 @@
+.create_new_refutation {
+  display: flex;
+}
+
+.create_new_refutation_form {
+  margin-left: 30px;
+}

--- a/app/controllers/agenda_boards_controller.rb
+++ b/app/controllers/agenda_boards_controller.rb
@@ -17,6 +17,7 @@ class AgendaBoardsController < ApplicationController
   def show
     @agenda_board = AgendaBoard.find(params[:id])
     @conclusions = @agenda_board.conclusions
+    @ref_conclusions = @agenda_board.ref_conclusions
   end
 
   def index

--- a/app/controllers/refutations_controller.rb
+++ b/app/controllers/refutations_controller.rb
@@ -12,7 +12,7 @@ class RefutationsController < ApplicationController
   end
 
 
-  end  def create
+  def create
     refutation = RefConclusion.new(refutation_params)
     if refutation.valid?
       flash[:notice] = "新規反論の作成に成功しました"
@@ -22,6 +22,7 @@ class RefutationsController < ApplicationController
       flash[:notice] = "新規反論の作成に失敗しました｡"
       render :new
     end
+  end
 
   private
 

--- a/app/controllers/refutations_controller.rb
+++ b/app/controllers/refutations_controller.rb
@@ -17,7 +17,6 @@ class RefutationsController < ApplicationController
     ref_reasons.ref_evidences.build
   end
 
-
   def create
     refutation = RefConclusion.new(refutation_params)
     if refutation.valid?
@@ -34,9 +33,9 @@ class RefutationsController < ApplicationController
 
   def refutation_params
     params.require(:ref_conclusion).permit(:agenda_board_id, :ref_conclusion_summary, :ref_conclusion_detail,
-      ref_reasons_attributes: [:id, :ref_reason_summary, :ref_reason_detail, :_destroy,
-        ref_evidences_attributes: [:id, :ref_evidence_summary, :ref_evidence_detail, :_destroy]
-      ]
-    )
+      ref_reasons_attributes: [
+        :id, :ref_reason_summary, :ref_reason_detail, :_destroy,
+        ref_evidences_attributes: [:id, :ref_evidence_summary, :ref_evidence_detail, :_destroy],
+      ])
   end
 end

--- a/app/controllers/refutations_controller.rb
+++ b/app/controllers/refutations_controller.rb
@@ -2,9 +2,15 @@ class RefutationsController < ApplicationController
   def new
     @agenda_board_id = params[:agenda_board_id].to_i
     @agenda_board_agenda = params[:agenda_board_agenda]
-    rebuttal_target_conclusion_id = params[:rebuttal_target_conclusion_id].to_i
-    @rebuttal_target_conclusion = Conclusion.find(rebuttal_target_conclusion_id)
-    @rebuttal_target_conclusion_index = params[:rebuttal_target_conclusion_index]
+    if params[:type_of_opinion] == "argument"
+      rebuttal_target_conclusion_id = params[:rebuttal_target_conclusion_id].to_i
+      @rebuttal_target_conclusion = Conclusion.find(rebuttal_target_conclusion_id)
+      @rebuttal_target_conclusion_index = params[:rebuttal_target_conclusion_index]
+    else
+      rebuttal_target_ref_conclusion_id = params[:rebuttal_target_ref_conclusion_id].to_i
+      @rebuttal_target_ref_conclusion = RefConclusion.find(rebuttal_target_ref_conclusion_id)
+      @rebuttal_target_ref_conclusion_index = params[:rebuttal_target_ref_conclusion_index]
+    end
 
     @ref_conclusion = RefConclusion.new
     ref_reasons = @ref_conclusion.ref_reasons.build

--- a/app/controllers/refutations_controller.rb
+++ b/app/controllers/refutations_controller.rb
@@ -1,0 +1,34 @@
+class RefutationsController < ApplicationController
+  def new
+    @agenda_board_id = params[:agenda_board_id].to_i
+    @agenda_board_agenda = params[:agenda_board_agenda]
+    rebuttal_target_conclusion_id = params[:rebuttal_target_conclusion_id].to_i
+    @rebuttal_target_conclusion = Conclusion.find(rebuttal_target_conclusion_id)
+    @rebuttal_target_conclusion_index = params[:rebuttal_target_conclusion_index]
+
+    @ref_conclusion = RefConclusion.new
+    ref_reasons = @ref_conclusion.ref_reasons.build
+    ref_reasons.ref_evidences.build
+  end
+
+  def create
+    refutation = RefConclusion.new(refutation_params)
+    if refutation.valid?
+      flash[:notice] = "新規反論の作成に成功しました"
+      refutation.save!
+    else
+      flash[:notice] = "新規反論の作成に失敗しました｡"
+      render :new
+    end
+  end
+
+  private
+
+  def refutation_params
+    params.require(:ref_conclusion).permit(:agenda_board_id, :ref_conclusion_summary, :ref_conclusion_detail,
+      ref_reasons_attributes: [:ref_reason_summary, :ref_reason_detail,
+        ref_evidences_attributes: [:ref_evidence_summary, :ref_evidence_detail]
+      ]
+    )
+  end
+end

--- a/app/controllers/refutations_controller.rb
+++ b/app/controllers/refutations_controller.rb
@@ -26,8 +26,8 @@ class RefutationsController < ApplicationController
 
   def refutation_params
     params.require(:ref_conclusion).permit(:agenda_board_id, :ref_conclusion_summary, :ref_conclusion_detail,
-      ref_reasons_attributes: [:ref_reason_summary, :ref_reason_detail,
-        ref_evidences_attributes: [:ref_evidence_summary, :ref_evidence_detail]
+      ref_reasons_attributes: [:id, :ref_reason_summary, :ref_reason_detail, :_destroy,
+        ref_evidences_attributes: [:id, :ref_evidence_summary, :ref_evidence_detail, :_destroy]
       ]
     )
   end

--- a/app/controllers/refutations_controller.rb
+++ b/app/controllers/refutations_controller.rb
@@ -11,16 +11,17 @@ class RefutationsController < ApplicationController
     ref_reasons.ref_evidences.build
   end
 
-  def create
+
+  end  def create
     refutation = RefConclusion.new(refutation_params)
     if refutation.valid?
       flash[:notice] = "新規反論の作成に成功しました"
       refutation.save!
+      redirect_to agenda_board_path(refutation.agenda_board_id)
     else
       flash[:notice] = "新規反論の作成に失敗しました｡"
       render :new
     end
-  end
 
   private
 

--- a/app/javascript/packs/rebuttal_target_argument.js
+++ b/app/javascript/packs/rebuttal_target_argument.js
@@ -1,0 +1,122 @@
+jsPlumb.ready(function() {
+  // 反論対象の主張の表示がツリー型になるよう接続線を引く + 反論対象の主張内にターゲットエンドポイントを設置する
+  const conclusions = document.querySelectorAll(".conclusion");
+  conclusions.forEach( function( conclusion ) {
+    const conclusion_id = conclusion.getAttribute("id");
+
+    // 結論の左右中央にターゲットエンドポイントを設置する
+    jsPlumb.addEndpoint(`${conclusion_id}`, {
+      endpoint: "Dot",
+      anchor: "RightMiddle",
+      isTarget: true,
+      connectionType: "red-connection"
+    })
+    jsPlumb.addEndpoint(`${conclusion_id}`, {
+      endpoint: "Dot",
+      anchor: "LeftMiddle",
+      isTarget: true,
+      connectionType: "red-connection"
+    })
+
+    const reasons_of_conclusion = document.querySelectorAll(`.reason_of_${conclusion_id}`);
+    reasons_of_conclusion.forEach( function( reason ) {
+      const reason_id = reason.getAttribute("id");
+
+      // 結論 → endpoint 間に接続線を引く
+      jsPlumb.connect({
+        source: `${conclusion_id}`,
+        target: `endpoint_between_${conclusion_id}_and_${reason_id}`,
+        anchors: ["Bottom", "Top"],
+        connector: "Straight",
+        endpoint:"Blank",
+        overlays:[
+          ["Arrow", {width: 10, length: 10}]
+        ]
+      });
+
+      // endpointの真ん中にターゲットエンドポイントを設置する
+      jsPlumb.addEndpoint(`endpoint_between_${conclusion_id}_and_${reason_id}`, {
+        endpoint: "Dot",
+        anchor: "Center",
+        isTarget: true,
+        connectionType: "red-connection"
+      })
+
+      // endpoint → 理由 間に接続線を引く
+      jsPlumb.connect({
+        source: `endpoint_between_${conclusion_id}_and_${reason_id}`,
+        target: `${reason_id}`,
+        anchors: ["Bottom", "Top"],
+        connector: "Straight",
+        endpoint:"Blank",
+        overlays:[
+          ["Arrow", {width: 10, length: 10}]
+        ]
+      });
+
+      // 理由の左右中央にターゲットエンドポイントを設置する
+      jsPlumb.addEndpoint(`${reason_id}`, {
+        endpoint: "Dot",
+        anchor: "RightMiddle",
+        isTarget: true,
+        connectionType: "red-connection"
+      })
+      jsPlumb.addEndpoint(`${reason_id}`, {
+        endpoint: "Dot",
+        anchor: "LeftMiddle",
+        isTarget: true,
+        connectionType: "red-connection"
+      })
+
+      const evidences_of_reason = document.querySelectorAll(`.evidence_of_${reason_id}`);
+      evidences_of_reason.forEach( function( evidence ) {
+        const evidence_id = evidence.getAttribute("id");
+        // 理由 → endpoint 間に接続線を引く
+        jsPlumb.connect({
+          source: `${reason_id}`,
+          target: `endpoint_between_${reason_id}_and_${evidence_id}`,
+          anchors: ["Bottom", "Top"],
+          connector: "Straight",
+          endpoint:"Blank",
+          overlays:[
+            ["Arrow", {width: 10, length: 10}]
+          ]
+        });
+
+        // endpointの真ん中にターゲットエンドポイントを設置する
+        jsPlumb.addEndpoint(`endpoint_between_${reason_id}_and_${evidence_id}`, {
+          endpoint: "Dot",
+          anchor: "Center",
+          isTarget: true,
+          connectionType: "red-connection"
+        })
+
+        // endpoint → 証拠 間に接続線を引く
+        jsPlumb.connect({
+          source: `endpoint_between_${reason_id}_and_${evidence_id}`,
+          target: `${evidence_id}`,
+          anchors: ["Bottom", "Top"],
+          connector: "Straight",
+          endpoint:"Blank",
+          overlays:[
+            ["Arrow", {width: 10, length: 10}]
+          ]
+        });
+
+        // 証拠の左右中央にターゲットエンドポイントを設置する
+        jsPlumb.addEndpoint(`${evidence_id}`, {
+          endpoint: "Dot",
+          anchor: "RightMiddle",
+          isTarget: true,
+          connectionType: "red-connection"
+        })
+        jsPlumb.addEndpoint(`${evidence_id}`, {
+          endpoint: "Dot",
+          anchor: "LeftMiddle",
+          isTarget: true,
+          connectionType: "red-connection"
+        })
+      });
+    });
+  });
+});

--- a/app/javascript/packs/rebuttal_target_argument.js
+++ b/app/javascript/packs/rebuttal_target_argument.js
@@ -119,4 +119,125 @@ jsPlumb.ready(function() {
       });
     });
   });
+  
+  // 反論対象の反論の表示がツリー型になるよう接続線を引く + 反論対象の反論内にターゲットエンドポイントを設置する
+  const ref_conclusions = document.querySelectorAll(".ref_conclusion");
+  ref_conclusions.forEach( function( ref_conclusion ) {
+    const ref_conclusion_id = ref_conclusion.getAttribute("id");
+
+    // 結論の左右中央にターゲットエンドポイントを設置する
+    jsPlumb.addEndpoint(`${ref_conclusion_id}`, {
+      endpoint: "Dot",
+      anchor: "RightMiddle",
+      isTarget: true,
+      connectionType: "red-connection"
+    })
+    jsPlumb.addEndpoint(`${ref_conclusion_id}`, {
+      endpoint: "Dot",
+      anchor: "LeftMiddle",
+      isTarget: true,
+      connectionType: "red-connection"
+    })
+
+    const ref_reasons_of_ref_conclusion = document.querySelectorAll(`.ref_reason_of_${ref_conclusion_id}`);
+    ref_reasons_of_ref_conclusion.forEach( function( ref_reason ) {
+      const ref_reason_id = ref_reason.getAttribute("id");
+
+      // 結論 → endpoint 間に接続線を引く
+      jsPlumb.connect({
+        source: `${ref_conclusion_id}`,
+        target: `endpoint_between_${ref_conclusion_id}_and_${ref_reason_id}`,
+        anchors: ["Bottom", "Top"],
+        connector: "Straight",
+        endpoint:"Blank",
+        overlays:[
+          ["Arrow", {width: 10, length: 10}]
+        ]
+      });
+
+      // endpointの真ん中にターゲットエンドポイントを設置する
+      jsPlumb.addEndpoint(`endpoint_between_${ref_conclusion_id}_and_${ref_reason_id}`, {
+        endpoint: "Dot",
+        anchor: "Center",
+        isTarget: true,
+        connectionType: "red-connection"
+      })
+
+      // endpoint → 理由 間に接続線を引く
+      jsPlumb.connect({
+        source: `endpoint_between_${ref_conclusion_id}_and_${ref_reason_id}`,
+        target: `${ref_reason_id}`,
+        anchors: ["Bottom", "Top"],
+        connector: "Straight",
+        endpoint:"Blank",
+        overlays:[
+          ["Arrow", {width: 10, length: 10}]
+        ]
+      });
+
+      // 理由の左右中央にターゲットエンドポイントを設置する
+      jsPlumb.addEndpoint(`${ref_reason_id}`, {
+        endpoint: "Dot",
+        anchor: "RightMiddle",
+        isTarget: true,
+        connectionType: "red-connection"
+      })
+      jsPlumb.addEndpoint(`${ref_reason_id}`, {
+        endpoint: "Dot",
+        anchor: "LeftMiddle",
+        isTarget: true,
+        connectionType: "red-connection"
+      })
+
+      const ref_evidences_of_ref_reason = document.querySelectorAll(`.ref_evidence_of_${ref_reason_id}`);
+      ref_evidences_of_ref_reason.forEach( function( ref_evidence ) {
+        const ref_evidence_id = ref_evidence.getAttribute("id");
+        // 理由 → endpoint 間に接続線を引く
+        jsPlumb.connect({
+          source: `${ref_reason_id}`,
+          target: `endpoint_between_${ref_reason_id}_and_${ref_evidence_id}`,
+          anchors: ["Bottom", "Top"],
+          connector: "Straight",
+          endpoint:"Blank",
+          overlays:[
+            ["Arrow", {width: 10, length: 10}]
+          ]
+        });
+
+        // endpointの真ん中にターゲットエンドポイントを設置する
+        jsPlumb.addEndpoint(`endpoint_between_${ref_reason_id}_and_${ref_evidence_id}`, {
+          endpoint: "Dot",
+          anchor: "Center",
+          isTarget: true,
+          connectionType: "red-connection"
+        })
+
+        // endpoint → 証拠 間に接続線を引く
+        jsPlumb.connect({
+          source: `endpoint_between_${ref_reason_id}_and_${ref_evidence_id}`,
+          target: `${ref_evidence_id}`,
+          anchors: ["Bottom", "Top"],
+          connector: "Straight",
+          endpoint:"Blank",
+          overlays:[
+            ["Arrow", {width: 10, length: 10}]
+          ]
+        });
+
+        // 証拠の左右中央にターゲットエンドポイントを設置する
+        jsPlumb.addEndpoint(`${ref_evidence_id}`, {
+          endpoint: "Dot",
+          anchor: "RightMiddle",
+          isTarget: true,
+          connectionType: "red-connection"
+        })
+        jsPlumb.addEndpoint(`${ref_evidence_id}`, {
+          endpoint: "Dot",
+          anchor: "LeftMiddle",
+          isTarget: true,
+          connectionType: "red-connection"
+        })
+      });
+    });
+  });
 });

--- a/app/models/agenda_board.rb
+++ b/app/models/agenda_board.rb
@@ -1,4 +1,5 @@
 class AgendaBoard < ApplicationRecord
   belongs_to :user
   has_many :conclusions
+  has_many :ref_conclusions
 end

--- a/app/models/ref_conclusion.rb
+++ b/app/models/ref_conclusion.rb
@@ -1,4 +1,8 @@
 class RefConclusion < ApplicationRecord
   belongs_to :agenda_board
   has_many :ref_reasons
+  accepts_nested_attributes_for :ref_reasons
+
+  validates :agenda_board_id, presence: true
+  validates :ref_conclusion_summary, presence: true
 end

--- a/app/models/ref_conclusion.rb
+++ b/app/models/ref_conclusion.rb
@@ -1,3 +1,4 @@
 class RefConclusion < ApplicationRecord
   belongs_to :agenda_board
+  has_many :ref_reasons
 end

--- a/app/models/ref_conclusion.rb
+++ b/app/models/ref_conclusion.rb
@@ -1,0 +1,3 @@
+class RefConclusion < ApplicationRecord
+  belongs_to :agenda_board
+end

--- a/app/models/ref_conclusion.rb
+++ b/app/models/ref_conclusion.rb
@@ -1,7 +1,7 @@
 class RefConclusion < ApplicationRecord
   belongs_to :agenda_board
-  has_many :ref_reasons
-  accepts_nested_attributes_for :ref_reasons
+  has_many :ref_reasons, dependent: :destroy
+  accepts_nested_attributes_for :ref_reasons, allow_destroy: true
 
   validates :agenda_board_id, presence: true
   validates :ref_conclusion_summary, presence: true

--- a/app/models/ref_evidence.rb
+++ b/app/models/ref_evidence.rb
@@ -1,0 +1,3 @@
+class RefEvidence < ApplicationRecord
+  belongs_to :ref_reason
+end

--- a/app/models/ref_evidence.rb
+++ b/app/models/ref_evidence.rb
@@ -1,3 +1,5 @@
 class RefEvidence < ApplicationRecord
   belongs_to :ref_reason
+
+  validates :ref_evidence_summary, presence: true
 end

--- a/app/models/ref_reason.rb
+++ b/app/models/ref_reason.rb
@@ -1,4 +1,7 @@
 class RefReason < ApplicationRecord
   belongs_to :ref_conclusion
   has_many :ref_evidences
+  accepts_nested_attributes_for :ref_evidences
+
+  validates :ref_reason_summary, presence: true
 end

--- a/app/models/ref_reason.rb
+++ b/app/models/ref_reason.rb
@@ -1,3 +1,4 @@
 class RefReason < ApplicationRecord
   belongs_to :ref_conclusion
+  has_many :ref_evidences
 end

--- a/app/models/ref_reason.rb
+++ b/app/models/ref_reason.rb
@@ -1,7 +1,7 @@
 class RefReason < ApplicationRecord
   belongs_to :ref_conclusion
-  has_many :ref_evidences
-  accepts_nested_attributes_for :ref_evidences
+  has_many :ref_evidences, dependent: :destroy
+  accepts_nested_attributes_for :ref_evidences, allow_destroy: true
 
   validates :ref_reason_summary, presence: true
 end

--- a/app/models/ref_reason.rb
+++ b/app/models/ref_reason.rb
@@ -1,0 +1,3 @@
+class RefReason < ApplicationRecord
+  belongs_to :ref_conclusion
+end

--- a/app/views/agenda_boards/show.html.erb
+++ b/app/views/agenda_boards/show.html.erb
@@ -55,101 +55,59 @@
         <%= button_to "新規反論作成", new_refutation_path, method: :get, params: {agenda_board_id: @agenda_board.id, agenda_board_agenda: @agenda_board.agenda, rebuttal_target_conclusion_id: conclusion.id, rebuttal_target_conclusion_index: "#{c_i}" } %>
       </div>
     <% end %>
-      <div class="refutation" id="refutation0">
+    <% @ref_conclusions.each_with_index do |ref_conclusion, r_c_i| %>
+      <div class="refutation" id="refutation<%= r_c_i %>">
         <h3 class="type_of_opinion">反論</h3>
         <div class="tree_structure">
-          <div class="ref_conclusion box" id="ref_conclusion0">
-            <h3>反論</h3>
+          <div class="ref_conclusion box" id="ref_conclusion<%= r_c_i %>">
+            <h3>結論</h3>
             <div class="inner">
-              理由詳細の部分に誤りがある｡
+              <%= ref_conclusion.ref_conclusion_summary %>
             </div>
-            <h3>反論詳細</h3>
+            <h3>結論詳細</h3>
             <div class="inner">
-              提示された､｢体内時計的に最適な起床時間｣は誤りである｡
+              <%= ref_conclusion.ref_conclusion_detail %>
             </div>
           </div>
 
           <div class="bases">
-            <div class="basis">
-              <div class="endpoint endpoint_between_ref_conclusion0_and_ref_reason" id="endpoint_between_ref_conclusion0_and_ref_reason0_of_ref_conclusion0"></div>
-              <div class="ref_reason box ref_reason_of_ref_conclusion0" id="ref_reason0_of_ref_conclusion0">
-                <h3>理由</h3>
-                <div class="inner">
-                  体内時計は同年齢間においても個人差があり､一律ではないから
-                </div>
-                <h3>理由詳細</h3>
-                <div class="inner">
-                  0時過ぎに寝て8時頃に起きるのが自然のリズムである人が最も多く、一方で、1:30以降に寝て9:30以降に起きるような夜型の人や、逆に22:30頃前に寝て6:30以前に自然に起きるような朝型の人もいる｡
-                </div>
-              </div>
-
-              <div class="evidences">
-                <div class="ref_evidence">
-                  <div class="endpoint endpoint_between_ref_reason0_of_ref_conclusion0_and_ref_evidence" id="endpoint_between_ref_reason0_of_ref_conclusion0_and_ref_evidence0_of_ref_reason0_of_ref_conclusion0"></div>
-                  <div class="ref_evidence box ref_evidence_of_ref_reason0_of_ref_conclusion0" id="ref_evidence0_of_ref_reason0_of_ref_conclusion0">
-                    <h3>証拠</h3>
-                    <div class="inner">
-                      8155名のMSFsc(睡眠負債がない状態において、自然に眠り自然に起きる時の、睡眠時間帯の中間時刻)調査結果
-                    </div>
-                    <h3>証拠詳細</h3>
-                    <div class="inner">
-                      https://team.tokyo-med.ac.jp/omh/news/202203_chronotype/
-                    </div>
+            <% ref_conclusion.ref_reasons.each_with_index do |ref_reason, r_r_i| %>
+              <div class="basis">
+                <div class="endpoint endpoint_between_ref_conclusion<%= r_c_i %>_and_ref_reason" id="endpoint_between_ref_conclusion<%= r_c_i %>_and_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>"></div>
+                <div class="ref_reason box ref_reason_of_ref_conclusion<%= r_c_i %>" id="ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>">
+                  <h3>理由</h3>
+                  <div class="inner">
+                    <%= ref_reason.ref_reason_summary %>
+                  </div>
+                  <h3>理由詳細</h3>
+                  <div class="inner">
+                    <%= ref_reason.ref_reason_detail %>
                   </div>
                 </div>
+
+                <div class="evidences">
+                  <% ref_reason.ref_evidences.each_with_index do |ref_evidence, e_i| %>
+                    <div class="ref_evidence">
+                      <div class="endpoint endpoint_between_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>_and_ref_evidence" id="endpoint_between_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>_and_ref_evidence<%= e_i %>_of_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>"></div>
+                      <div class="ref_evidence box ref_evidence_of_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>" id="ref_evidence<%= e_i %>_of_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>">
+                        <h3>証拠</h3>
+                        <div class="inner">
+                          <%= ref_evidence.ref_evidence_summary %>
+                        </div>
+                        <h3>証拠詳細</h3>
+                        <div class="inner">
+                          <%= ref_evidence.ref_evidence_detail %>
+                        </div>
+                      </div>
+                    </div>
+                  <% end %>
+                </div>
               </div>
-            </div>
+            <% end %>
           </div>
         </div>
       </div>
-
-      <div class="refutation" id="refutation1">
-        <h3 class="type_of_opinion">反論</h3>
-        <div class="tree_structure">
-          <div class="ref_conclusion box" id="ref_conclusion1">
-            <h3>反論</h3>
-            <div class="inner">
-              証拠が理由に適するものではない
-            </div>
-            <h3>反論詳細</h3>
-            <div class="inner">
-              特になし
-            </div>
-          </div>
-
-          <div class="bases">
-            <div class="basis">
-              <div class="endpoint endpoint_between_ref_conclusion1_and_ref_reason" id="endpoint_between_ref_conclusion1_and_ref_reason0_of_ref_conclusion1"></div>
-              <div class="ref_reason box ref_reason_of_ref_conclusion1" id="ref_reason0_of_ref_conclusion1">
-                <h3>理由</h3>
-                <div class="inner">
-                  証拠にあげている調査は､同年齢を対象としたものではないから｡
-                </div>
-                <h3>理由詳細</h3>
-                <div class="inner">
-                  提示された調査は､様々な年齢の人々(平均年齢は36.7歳)を対象にしたものなので､｢体内時計は同年齢間においても個人差がある｣ということの証拠として適当ではない
-                </div>
-              </div>
-
-              <div class="evidences">
-                <div class="ref_evidence">
-                  <div class="endpoint endpoint_between_ref_reason0_of_ref_conclusion1_and_ref_evidence" id="endpoint_between_ref_reason0_of_ref_conclusion1_and_ref_evidence0_of_ref_reason0_of_ref_conclusion1"></div>
-                  <div class="ref_evidence box ref_evidence_of_ref_reason0_of_ref_conclusion1" id="ref_evidence0_of_ref_reason0_of_ref_conclusion1">
-                    <h3>証拠</h3>
-                    <div class="inner">
-                      論理性の話であるため､必要なし
-                    </div>
-                    <h3>証拠詳細</h3>
-                    <div class="inner">
-                      特になし
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+    <% end %>
     </div>
   <%= button_to "新規主張作成", new_argument_path, method: :get, params: {agenda_board_id: @agenda_board.id, agenda_board_agenda: @agenda_board.agenda} %>
 </div>

--- a/app/views/agenda_boards/show.html.erb
+++ b/app/views/agenda_boards/show.html.erb
@@ -52,6 +52,7 @@
             <% end %>
           </div>
         </div>
+        <%= button_to "新規反論作成", new_refutation_path, method: :get, params: {agenda_board_id: @agenda_board.id, agenda_board_agenda: @agenda_board.agenda, rebuttal_target_conclusion_id: conclusion.id, rebuttal_target_conclusion_index: "#{c_i}" } %>
       </div>
     <% end %>
       <div class="refutation" id="refutation0">

--- a/app/views/agenda_boards/show.html.erb
+++ b/app/views/agenda_boards/show.html.erb
@@ -3,7 +3,7 @@
     <div id="exchange_of_opinions">
     <% @conclusions.each_with_index do |conclusion, c_i| %>
       <div class="argument" id="argument<%= c_i %>">
-        <h3 class="type_of_opinion">主張</h3>
+        <h3 class="argument_title">主張</h3>
         <div class="tree_structure">
           <div class="conclusion box" id="conclusion<%= c_i %>">
             <h3>結論</h3>
@@ -57,9 +57,9 @@
     <% end %>
     <% @ref_conclusions.each_with_index do |ref_conclusion, r_c_i| %>
       <div class="refutation" id="refutation<%= r_c_i %>">
-        <h3 class="type_of_opinion">反論</h3>
-        <div class="tree_structure">
-          <div class="ref_conclusion box" id="ref_conclusion<%= r_c_i %>">
+        <h3 class="refutation_title">反論</h3>
+        <div class="ref_tree_structure">
+          <div class="ref_conclusion ref_box" id="ref_conclusion<%= r_c_i %>">
             <h3>結論</h3>
             <div class="inner">
               <%= ref_conclusion.ref_conclusion_summary %>
@@ -74,7 +74,7 @@
             <% ref_conclusion.ref_reasons.each_with_index do |ref_reason, r_r_i| %>
               <div class="basis">
                 <div class="endpoint endpoint_between_ref_conclusion<%= r_c_i %>_and_ref_reason" id="endpoint_between_ref_conclusion<%= r_c_i %>_and_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>"></div>
-                <div class="ref_reason box ref_reason_of_ref_conclusion<%= r_c_i %>" id="ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>">
+                <div class="ref_reason ref_box ref_reason_of_ref_conclusion<%= r_c_i %>" id="ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>">
                   <h3>理由</h3>
                   <div class="inner">
                     <%= ref_reason.ref_reason_summary %>
@@ -89,7 +89,7 @@
                   <% ref_reason.ref_evidences.each_with_index do |ref_evidence, e_i| %>
                     <div class="ref_evidence">
                       <div class="endpoint endpoint_between_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>_and_ref_evidence" id="endpoint_between_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>_and_ref_evidence<%= e_i %>_of_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>"></div>
-                      <div class="ref_evidence box ref_evidence_of_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>" id="ref_evidence<%= e_i %>_of_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>">
+                      <div class="ref_evidence ref_box ref_evidence_of_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>" id="ref_evidence<%= e_i %>_of_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>">
                         <h3>証拠</h3>
                         <div class="inner">
                           <%= ref_evidence.ref_evidence_summary %>

--- a/app/views/agenda_boards/show.html.erb
+++ b/app/views/agenda_boards/show.html.erb
@@ -52,7 +52,7 @@
             <% end %>
           </div>
         </div>
-        <%= button_to "新規反論作成", new_refutation_path, method: :get, params: {agenda_board_id: @agenda_board.id, agenda_board_agenda: @agenda_board.agenda, rebuttal_target_conclusion_id: conclusion.id, rebuttal_target_conclusion_index: "#{c_i}" } %>
+        <%= button_to "新規反論作成", new_refutation_path, method: :get, params: {agenda_board_id: @agenda_board.id, agenda_board_agenda: @agenda_board.agenda, rebuttal_target_conclusion_id: conclusion.id, rebuttal_target_conclusion_index: "#{c_i}", type_of_opinion: "argument" } %>
       </div>
     <% end %>
     <% @ref_conclusions.each_with_index do |ref_conclusion, r_c_i| %>
@@ -86,10 +86,10 @@
                 </div>
 
                 <div class="evidences">
-                  <% ref_reason.ref_evidences.each_with_index do |ref_evidence, e_i| %>
+                  <% ref_reason.ref_evidences.each_with_index do |ref_evidence, r_e_i| %>
                     <div class="ref_evidence">
-                      <div class="endpoint endpoint_between_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>_and_ref_evidence" id="endpoint_between_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>_and_ref_evidence<%= e_i %>_of_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>"></div>
-                      <div class="ref_evidence ref_box ref_evidence_of_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>" id="ref_evidence<%= e_i %>_of_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>">
+                      <div class="endpoint endpoint_between_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>_and_ref_evidence" id="endpoint_between_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>_and_ref_evidence<%= r_e_i %>_of_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>"></div>
+                      <div class="ref_evidence ref_box ref_evidence_of_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>" id="ref_evidence<%= r_e_i %>_of_ref_reason<%= r_r_i %>_of_ref_conclusion<%= r_c_i %>">
                         <h3>証拠</h3>
                         <div class="inner">
                           <%= ref_evidence.ref_evidence_summary %>
@@ -106,6 +106,7 @@
             <% end %>
           </div>
         </div>
+        <%= button_to "新規反論作成", new_refutation_path, method: :get, params: {agenda_board_id: @agenda_board.id, agenda_board_agenda: @agenda_board.agenda, rebuttal_target_ref_conclusion_id: ref_conclusion.id, rebuttal_target_ref_conclusion_index: "#{r_c_i}" } %>
       </div>
     <% end %>
     </div>

--- a/app/views/refutations/_ref_evidence_fields.html.erb
+++ b/app/views/refutations/_ref_evidence_fields.html.erb
@@ -1,0 +1,7 @@
+<div class="nested-fields">
+  <%= f.label :ref_evidence_summary, "証拠" %>
+  <%= f.text_field :ref_evidence_summary %>
+  <%= f.label :ref_evidence_detail, "証拠詳細" %>
+  <%= f.text_area :ref_evidence_detail %>
+  <%= link_to_remove_association "証拠を削除", f %>
+</div>

--- a/app/views/refutations/_ref_reason_fields.html.erb
+++ b/app/views/refutations/_ref_reason_fields.html.erb
@@ -1,0 +1,17 @@
+<div class="nested-fields">
+  <%= f.label :ref_reason_summary, "理由" %>
+  <%= f.text_field :ref_reason_summary %>
+  <%= f.label :ref_reason_detail, "理由詳細" %>
+  <%= f.text_area :ref_reason_detail %>
+  <%= link_to_remove_association "理由を削除", f %>
+
+  <div class="nested_ref_evidences_forms">
+    <%= f.fields_for :ref_evidences do |nested_ref_evidence_form| %>
+      <%= render "ref_evidence_fields", f: nested_ref_evidence_form %>
+    <% end %>
+  </div>
+
+  <div class="add_nested_ref_evidence_form">
+    <%= link_to_add_association "証拠を追加", f, :ref_evidences, data: { association_insertion_method: 'after' } %>
+  </div>
+</div>

--- a/app/views/refutations/new.html.erb
+++ b/app/views/refutations/new.html.erb
@@ -54,33 +54,43 @@
 
   <div class="create_new_refutation_form">
     <h2>新規反論</h2>
-    <%= form_with model: @ref_conclusion, url: refutations_path do |ref_conclusion_form| %>
+    <%= form_with model: @ref_conclusion, url: refutations_path, local: true do |ref_conclusion_form| %>
       <%= ref_conclusion_form.hidden_field :agenda_board_id, value: @agenda_board_id %>
       <%= ref_conclusion_form.label :ref_conclusion_summary, "結論" %>
       <%= ref_conclusion_form.text_field :ref_conclusion_summary %>
       <%= ref_conclusion_form.label :ref_conclusion_detail, "結論詳細" %>
       <%= ref_conclusion_form.text_area :ref_conclusion_detail %>
 
-      <div class="ref_basis">
-        <%= ref_conclusion_form.fields_for :ref_reasons do |ref_reason_form| %>
-          <div class="nested_field">
-            <%= ref_reason_form.label :ref_reason_summary, "理由" %>
-            <%= ref_reason_form.text_field :ref_reason_summary %>
-            <%= ref_reason_form.label :ref_reason_detail, "理由詳細" %>
-            <%= ref_reason_form.text_area :ref_reason_detail %>
+      <div class="nested_ref_bases_forms">
+        <%= ref_conclusion_form.fields_for :ref_reasons do |nested_ref_reason_form| %>
+          <div class="nested-fields">
+            <%= nested_ref_reason_form.label :ref_reason_summary, "理由" %>
+            <%= nested_ref_reason_form.text_field :ref_reason_summary %>
+            <%= nested_ref_reason_form.label :ref_reason_detail, "理由詳細" %>
+            <%= nested_ref_reason_form.text_area :ref_reason_detail %>
+            <%= link_to_remove_association "理由を削除", nested_ref_reason_form %>
 
-            <div class="ref_evidence">
-              <%= ref_reason_form.fields_for :ref_evidences do |ref_evidence_form| %>
-                <div class="nested_field">
-                  <%= ref_evidence_form.label :ref_evidence_summary, "証拠" %>
-                  <%= ref_evidence_form.text_field :ref_evidence_summary %>
-                  <%= ref_evidence_form.label :ref_evidence_detail, "証拠詳細" %>
-                  <%= ref_evidence_form.text_area :ref_evidence_detail %>
+            <div class="nested_ref_evidences_forms">
+              <%= nested_ref_reason_form.fields_for :ref_evidences do |nested_ref_evidence_form| %>
+                <div class="nested-fields">
+                  <%= nested_ref_evidence_form.label :ref_evidence_summary, "証拠" %>
+                  <%= nested_ref_evidence_form.text_field :ref_evidence_summary %>
+                  <%= nested_ref_evidence_form.label :ref_evidence_detail, "証拠詳細" %>
+                  <%= nested_ref_evidence_form.text_area :ref_evidence_detail %>
+                  <%= link_to_remove_association "証拠を削除", nested_ref_evidence_form %>
                 </div>
               <% end %>
             </div>
+
+            <div class="add_nested_ref_evidence_form">
+              <%= link_to_add_association "証拠を追加", nested_ref_reason_form, :ref_evidences, data: { association_insertion_method: 'after' } %>
+            </div>
           </div>
         <% end %>
+
+        <div class="add_nested_ref_reason_form">
+          <%= link_to_add_association "理由を追加", ref_conclusion_form, :ref_reasons %>
+        </div>
       </div>
       <div>
         <%= ref_conclusion_form.submit "新規反論を作成する" %>

--- a/app/views/refutations/new.html.erb
+++ b/app/views/refutations/new.html.erb
@@ -63,29 +63,7 @@
 
       <div class="nested_ref_bases_forms">
         <%= ref_conclusion_form.fields_for :ref_reasons do |nested_ref_reason_form| %>
-          <div class="nested-fields">
-            <%= nested_ref_reason_form.label :ref_reason_summary, "理由" %>
-            <%= nested_ref_reason_form.text_field :ref_reason_summary %>
-            <%= nested_ref_reason_form.label :ref_reason_detail, "理由詳細" %>
-            <%= nested_ref_reason_form.text_area :ref_reason_detail %>
-            <%= link_to_remove_association "理由を削除", nested_ref_reason_form %>
-
-            <div class="nested_ref_evidences_forms">
-              <%= nested_ref_reason_form.fields_for :ref_evidences do |nested_ref_evidence_form| %>
-                <div class="nested-fields">
-                  <%= nested_ref_evidence_form.label :ref_evidence_summary, "証拠" %>
-                  <%= nested_ref_evidence_form.text_field :ref_evidence_summary %>
-                  <%= nested_ref_evidence_form.label :ref_evidence_detail, "証拠詳細" %>
-                  <%= nested_ref_evidence_form.text_area :ref_evidence_detail %>
-                  <%= link_to_remove_association "証拠を削除", nested_ref_evidence_form %>
-                </div>
-              <% end %>
-            </div>
-
-            <div class="add_nested_ref_evidence_form">
-              <%= link_to_add_association "証拠を追加", nested_ref_reason_form, :ref_evidences, data: { association_insertion_method: 'after' } %>
-            </div>
-          </div>
+          <%= render "ref_reason_fields", f: nested_ref_reason_form %>
         <% end %>
 
         <div class="add_nested_ref_reason_form">

--- a/app/views/refutations/new.html.erb
+++ b/app/views/refutations/new.html.erb
@@ -1,0 +1,96 @@
+<h1><%= @agenda_board_agenda %></h1>
+<div class="create_new_refutation">
+  <div class="rebuttal_target_argument" id="argument<%= @rebuttal_target_conclusion_index %>">
+    <h3 class="type_of_opinion">反論対象の主張</h3>
+    <div class="tree_structure">
+      <div class="conclusion box" id="conclusion<%= @rebuttal_target_conclusion_index %>">
+        <h3>結論</h3>
+        <div class="inner">
+          <%= @rebuttal_target_conclusion.conclusion_summary %>
+        </div>
+        <h3>結論詳細</h3>
+        <div class="inner">
+          <%= @rebuttal_target_conclusion.conclusion_detail %>
+        </div>
+      </div>
+
+      <div class="bases">
+        <% @rebuttal_target_conclusion.reasons.each_with_index do |reason, r_i| %>
+          <div class="basis">
+            <div class="endpoint endpoint_between_conclusion<%= @rebuttal_target_conclusion_index %>_and_reason" id="endpoint_between_conclusion<%= @rebuttal_target_conclusion_index %>_and_reason<%= r_i %>_of_conclusion<%= @rebuttal_target_conclusion_index %>"></div>
+            <div class="reason box reason_of_conclusion<%= @rebuttal_target_conclusion_index %>" id="reason<%= r_i %>_of_conclusion<%= @rebuttal_target_conclusion_index %>">
+              <h3>理由</h3>
+              <div class="inner">
+                <%= reason.reason_summary %>
+              </div>
+              <h3>理由詳細</h3>
+              <div class="inner">
+                <%= reason.reason_detail %>
+              </div>
+            </div>
+
+            <div class="evidences">
+              <% reason.evidences.each_with_index do |evidence, e_i| %>
+                <div class="evidence">
+                  <div class="endpoint endpoint_between_reason<%= r_i %>_of_conclusion<%= @rebuttal_target_conclusion_index %>_and_evidence" id="endpoint_between_reason<%= r_i %>_of_conclusion<%= @rebuttal_target_conclusion_index %>_and_evidence<%= e_i %>_of_reason<%= r_i %>_of_conclusion<%= @rebuttal_target_conclusion_index %>"></div>
+                  <div class="evidence box evidence_of_reason<%= r_i %>_of_conclusion<%= @rebuttal_target_conclusion_index %>" id="evidence<%= e_i %>_of_reason<%= r_i %>_of_conclusion<%= @rebuttal_target_conclusion_index %>">
+                    <h3>証拠</h3>
+                    <div class="inner">
+                      <%= evidence.evidence_summary %>
+                    </div>
+                    <h3>証拠詳細</h3>
+                    <div class="inner">
+                      <%= evidence.evidence_detail %>
+                    </div>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <div class="create_new_refutation_form">
+    <h2>新規反論</h2>
+    <%= form_with model: @ref_conclusion, url: refutations_path do |ref_conclusion_form| %>
+      <%= ref_conclusion_form.hidden_field :agenda_board_id, value: @agenda_board_id %>
+      <%= ref_conclusion_form.label :ref_conclusion_summary, "結論" %>
+      <%= ref_conclusion_form.text_field :ref_conclusion_summary %>
+      <%= ref_conclusion_form.label :ref_conclusion_detail, "結論詳細" %>
+      <%= ref_conclusion_form.text_area :ref_conclusion_detail %>
+
+      <div class="ref_basis">
+        <%= ref_conclusion_form.fields_for :ref_reasons do |ref_reason_form| %>
+          <div class="nested_field">
+            <%= ref_reason_form.label :ref_reason_summary, "理由" %>
+            <%= ref_reason_form.text_field :ref_reason_summary %>
+            <%= ref_reason_form.label :ref_reason_detail, "理由詳細" %>
+            <%= ref_reason_form.text_area :ref_reason_detail %>
+
+            <div class="ref_evidence">
+              <%= ref_reason_form.fields_for :ref_evidences do |ref_evidence_form| %>
+                <div class="nested_field">
+                  <%= ref_evidence_form.label :ref_evidence_summary, "証拠" %>
+                  <%= ref_evidence_form.text_field :ref_evidence_summary %>
+                  <%= ref_evidence_form.label :ref_evidence_detail, "証拠詳細" %>
+                  <%= ref_evidence_form.text_area :ref_evidence_detail %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+      <div>
+        <%= ref_conclusion_form.submit "新規反論を作成する" %>
+      </div>
+    <% end %>
+  </div>
+</div>
+<script
+src="https://code.jquery.com/jquery-3.5.1.min.js"
+integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
+crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jsPlumb/2.14.3/js/jsplumb.min.js"></script>
+<%= javascript_pack_tag 'rebuttal_target_argument' %>

--- a/app/views/refutations/new.html.erb
+++ b/app/views/refutations/new.html.erb
@@ -1,7 +1,8 @@
 <h1><%= @agenda_board_agenda %></h1>
 <div class="create_new_refutation">
+  <% if @rebuttal_target_conclusion %>
   <div class="rebuttal_target_argument" id="argument<%= @rebuttal_target_conclusion_index %>">
-    <h3 class="type_of_opinion">反論対象の主張</h3>
+    <h3 class="argument_title">反論対象の主張</h3>
     <div class="tree_structure">
       <div class="conclusion box" id="conclusion<%= @rebuttal_target_conclusion_index %>">
         <h3>結論</h3>
@@ -51,6 +52,59 @@
       </div>
     </div>
   </div>
+  <% else %>
+  <div class="rebuttal_target_refutation" id="refutation<%= @rebuttal_target_ref_conclusion_index %>">
+    <h3 class="refutation_title">反論対象の反論</h3>
+    <div class="ref_tree_structure">
+      <div class="ref_conclusion ref_box" id="ref_conclusion<%= @rebuttal_target_ref_conclusion_index %>">
+        <h3>結論</h3>
+        <div class="inner">
+          <%= @rebuttal_target_ref_conclusion.ref_conclusion_summary %>
+        </div>
+        <h3>結論詳細</h3>
+        <div class="inner">
+          <%= @rebuttal_target_ref_conclusion.ref_conclusion_detail %>
+        </div>
+      </div>
+
+      <div class="bases">
+        <% @rebuttal_target_ref_conclusion.ref_reasons.each_with_index do |ref_reason, r_r_i| %>
+          <div class="basis">
+            <div class="endpoint endpoint_between_ref_conclusion<%= @rebuttal_target_ref_conclusion_index %>_and_ref_reason" id="endpoint_between_ref_conclusion<%= @rebuttal_target_ref_conclusion_index %>_and_ref_reason<%= r_r_i %>_of_ref_conclusion<%= @rebuttal_target_ref_conclusion_index %>"></div>
+            <div class="ref_reason ref_box ref_reason_of_ref_conclusion<%= @rebuttal_target_ref_conclusion_index %>" id="ref_reason<%= r_r_i %>_of_ref_conclusion<%= @rebuttal_target_ref_conclusion_index %>">
+              <h3>理由</h3>
+              <div class="inner">
+                <%= ref_reason.ref_reason_summary %>
+              </div>
+              <h3>理由詳細</h3>
+              <div class="inner">
+                <%= ref_reason.ref_reason_detail %>
+              </div>
+            </div>
+
+            <div class="evidences">
+              <% ref_reason.ref_evidences.each_with_index do |ref_evidence, r_e_i| %>
+                <div class="ref_evidence">
+                  <div class="endpoint endpoint_between_ref_reason<%= r_r_i %>_of_ref_conclusion<%= @rebuttal_target_ref_conclusion_index %>_and_ref_evidence" id="endpoint_between_ref_reason<%= r_r_i %>_of_ref_conclusion<%= @rebuttal_target_ref_conclusion_index %>_and_ref_evidence<%= r_e_i %>_of_ref_reason<%= r_r_i %>_of_ref_conclusion<%= @rebuttal_target_ref_conclusion_index %>"></div>
+                  <div class="ref_evidence ref_box ref_evidence_of_ref_reason<%= r_r_i %>_of_ref_conclusion<%= @rebuttal_target_ref_conclusion_index %>" id="ref_evidence<%= r_e_i %>_of_ref_reason<%= r_r_i %>_of_ref_conclusion<%= @rebuttal_target_ref_conclusion_index %>">
+                    <h3>証拠</h3>
+                    <div class="inner">
+                      <%= ref_evidence.ref_evidence_summary %>
+                    </div>
+                    <h3>証拠詳細</h3>
+                    <div class="inner">
+                      <%= ref_evidence.ref_evidence_detail %>
+                    </div>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+  <% end %>
 
   <div class="create_new_refutation_form">
     <h2>新規反論</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,5 @@ Rails.application.routes.draw do
     get 'sign_out', :to => 'users/sessions#destroy'
   end
 
-  resources :agenda_boards, :arguments
+  resources :agenda_boards, :arguments, :refutations
 end

--- a/db/migrate/20230507082934_create_ref_conclusions.rb
+++ b/db/migrate/20230507082934_create_ref_conclusions.rb
@@ -1,0 +1,11 @@
+class CreateRefConclusions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :ref_conclusions do |t|
+      t.references :agenda_board, null: false, foreign_key: true
+      t.string :ref_conclusion_summary
+      t.text :ref_conclusion_detail
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230507085139_create_ref_reasons.rb
+++ b/db/migrate/20230507085139_create_ref_reasons.rb
@@ -1,0 +1,11 @@
+class CreateRefReasons < ActiveRecord::Migration[6.0]
+  def change
+    create_table :ref_reasons do |t|
+      t.references :ref_conclusion, null: false, foreign_key: true
+      t.string :ref_reason_summary
+      t.text :ref_reason_detail
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230507105304_create_ref_evidences.rb
+++ b/db/migrate/20230507105304_create_ref_evidences.rb
@@ -1,0 +1,11 @@
+class CreateRefEvidences < ActiveRecord::Migration[6.0]
+  def change
+    create_table :ref_evidences do |t|
+      t.references :ref_reason, null: false, foreign_key: true
+      t.string :ref_evidence_summary
+      t.text :ref_evidence_detail
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_07_082934) do
+ActiveRecord::Schema.define(version: 2023_05_07_085139) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,15 @@ ActiveRecord::Schema.define(version: 2023_05_07_082934) do
     t.index ["agenda_board_id"], name: "index_ref_conclusions_on_agenda_board_id"
   end
 
+  create_table "ref_reasons", force: :cascade do |t|
+    t.bigint "ref_conclusion_id", null: false
+    t.string "ref_reason_summary"
+    t.text "ref_reason_detail"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["ref_conclusion_id"], name: "index_ref_reasons_on_ref_conclusion_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", default: "", null: false
@@ -70,4 +79,5 @@ ActiveRecord::Schema.define(version: 2023_05_07_082934) do
   end
 
   add_foreign_key "ref_conclusions", "agenda_boards"
+  add_foreign_key "ref_reasons", "ref_conclusions"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_07_085139) do
+ActiveRecord::Schema.define(version: 2023_05_07_105304) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,15 @@ ActiveRecord::Schema.define(version: 2023_05_07_085139) do
     t.index ["agenda_board_id"], name: "index_ref_conclusions_on_agenda_board_id"
   end
 
+  create_table "ref_evidences", force: :cascade do |t|
+    t.bigint "ref_reason_id", null: false
+    t.string "ref_evidence_summary"
+    t.text "ref_evidence_detail"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["ref_reason_id"], name: "index_ref_evidences_on_ref_reason_id"
+  end
+
   create_table "ref_reasons", force: :cascade do |t|
     t.bigint "ref_conclusion_id", null: false
     t.string "ref_reason_summary"
@@ -79,5 +88,6 @@ ActiveRecord::Schema.define(version: 2023_05_07_085139) do
   end
 
   add_foreign_key "ref_conclusions", "agenda_boards"
+  add_foreign_key "ref_evidences", "ref_reasons"
   add_foreign_key "ref_reasons", "ref_conclusions"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_08_044932) do
+ActiveRecord::Schema.define(version: 2023_05_07_082934) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,15 @@ ActiveRecord::Schema.define(version: 2023_04_08_044932) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "ref_conclusions", force: :cascade do |t|
+    t.bigint "agenda_board_id", null: false
+    t.string "ref_conclusion_summary"
+    t.text "ref_conclusion_detail"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["agenda_board_id"], name: "index_ref_conclusions_on_agenda_board_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", default: "", null: false
@@ -60,4 +69,5 @@ ActiveRecord::Schema.define(version: 2023_04_08_044932) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "ref_conclusions", "agenda_boards"
 end

--- a/spec/factories/ref_conclusions.rb
+++ b/spec/factories/ref_conclusions.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :ref_conclusion do
+    agenda_board { nil }
+    ref_conclusion_summary { "MyString" }
+    ref_conclusion_detail { "MyText" }
+  end
+end

--- a/spec/factories/ref_evidences.rb
+++ b/spec/factories/ref_evidences.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :ref_evidence do
+    ref_reason { nil }
+    ref_evidence_summary { "MyString" }
+    ref_evidence_detail { "MyText" }
+  end
+end

--- a/spec/factories/ref_reasons.rb
+++ b/spec/factories/ref_reasons.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :ref_reason do
+    ref_conclusion { nil }
+    ref_reason_summary { "MyString" }
+    ref_reason_detail { "MyText" }
+  end
+end

--- a/spec/models/ref_conclusion_spec.rb
+++ b/spec/models/ref_conclusion_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe RefConclusion, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/ref_evidence_spec.rb
+++ b/spec/models/ref_evidence_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe RefEvidence, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/ref_reason_spec.rb
+++ b/spec/models/ref_reason_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe RefReason, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/system/agenda_boards_spec.rb
+++ b/spec/system/agenda_boards_spec.rb
@@ -2,14 +2,23 @@ require 'rails_helper'
 
 RSpec.describe "AgendaBoards", type: :system do
   let(:annie) { create(:user, name: "annie") }
+
   let(:about_early_bird) { create(:agenda_board, user_id: annie.id, agenda: "早起きは健康によいのか?", category: "自然科学") }
   let!(:about_chatbot) { create(:agenda_board, user_id: annie.id, agenda: "チャットボットは教育に悪影響を与えるのか?", category: "社会科学") }
+
   let(:bad_for_health) { create(:conclusion, agenda_board_id: about_early_bird.id, conclusion_summary: "健康に悪い") }
   let!(:good_for_health) { create(:conclusion, agenda_board_id: about_early_bird.id, conclusion_summary: "健康に良い") }
   let(:misalignment_with_body_clock) { create(:reason, conclusion_id: bad_for_health.id, reason_summary: "人間の体内時計と噛み合っていないから") }
   let!(:lack_of_sleep) { create(:reason, conclusion_id: bad_for_health.id, reason_summary: "睡眠不足になりやすいから") }
   let!(:sleep_data) { create(:evidence, reason_id: misalignment_with_body_clock.id, evidence_summary: "世界中のあらゆる人々の睡眠データ") }
   let!(:research_of_dr_kelly) { create(:evidence, reason_id: misalignment_with_body_clock.id, evidence_summary: "ケリー博士の研究") }
+
+  let(:problematic_reason) { create(:ref_conclusion, agenda_board_id: about_early_bird.id, ref_conclusion_summary: "理由部分に誤りがある") }
+  let!(:problematic_reason_and_evidence_connection) { create(:ref_conclusion, agenda_board_id: about_early_bird.id, ref_conclusion_summary: "証拠が理由に適するものではない") }
+  let(:individual_differences_in_body_clock) { create(:ref_reason, ref_conclusion_id: problematic_reason.id, ref_reason_summary: "体内時計は､同年齢間においても個人差があり､一律ではないから") }
+  let!(:resetting_the_body_clock) { create(:ref_reason, ref_conclusion_id: problematic_reason.id, ref_reason_summary: "体内時計は､日の光を浴びることでリセットされるから") }
+  let!(:results_of_sleep_time_survey) { create(:ref_evidence, ref_reason_id: individual_differences_in_body_clock.id, ref_evidence_summary: "8155名のMSFsc調査結果") }
+  let!(:research_on_the_body_clock) { create(:ref_evidence, ref_reason_id: individual_differences_in_body_clock.id, ref_evidence_summary: "体内時計に関する研究") }
 
   before do
     visit root_path
@@ -88,6 +97,23 @@ RSpec.describe "AgendaBoards", type: :system do
           reason.evidences.all? do |evidence|
             expect(page).to have_content evidence.evidence_summary
             expect(page).to have_content evidence.evidence_detail
+          end
+        end
+      end
+    end
+
+    scenario "すべての反論(結論+理由+証拠)を動的に確認できること" do
+      about_early_bird.ref_conclusions.all? do |ref_conclusion|
+        expect(page).to have_content ref_conclusion.ref_conclusion_summary
+        expect(page).to have_content ref_conclusion.ref_conclusion_detail
+
+        ref_conclusion.ref_reasons.all? do |ref_reason|
+          expect(page).to have_content ref_reason.ref_reason_summary
+          expect(page).to have_content ref_reason.ref_reason_summary
+
+          ref_reason.ref_evidences.all? do |ref_evidence|
+            expect(page).to have_content ref_evidence.ref_evidence_summary
+            expect(page).to have_content ref_evidence.ref_evidence_detail
           end
         end
       end

--- a/spec/system/agenda_boards_spec.rb
+++ b/spec/system/agenda_boards_spec.rb
@@ -71,6 +71,11 @@ RSpec.describe "AgendaBoards", type: :system do
       expect(page).to have_current_path new_argument_path, ignore_query: true
     end
 
+    scenario "｢新規反論作成｣ボタンをクリックすると､新規反論作成ページに遷移すること" do
+      click_button "新規反論作成", match: :first
+      expect(page).to have_current_path new_refutation_path, ignore_query: true
+    end
+
     scenario "すべての主張(結論+理由+証拠)を動的に確認できること" do
       about_early_bird.conclusions.all? do |conclusion|
         expect(page).to have_content conclusion.conclusion_summary

--- a/spec/system/agenda_boards_spec.rb
+++ b/spec/system/agenda_boards_spec.rb
@@ -14,11 +14,21 @@ RSpec.describe "AgendaBoards", type: :system do
   let!(:research_of_dr_kelly) { create(:evidence, reason_id: misalignment_with_body_clock.id, evidence_summary: "ケリー博士の研究") }
 
   let(:problematic_reason) { create(:ref_conclusion, agenda_board_id: about_early_bird.id, ref_conclusion_summary: "理由部分に誤りがある") }
-  let!(:problematic_reason_and_evidence_connection) { create(:ref_conclusion, agenda_board_id: about_early_bird.id, ref_conclusion_summary: "証拠が理由に適するものではない") }
-  let(:individual_differences_in_body_clock) { create(:ref_reason, ref_conclusion_id: problematic_reason.id, ref_reason_summary: "体内時計は､同年齢間においても個人差があり､一律ではないから") }
-  let!(:resetting_the_body_clock) { create(:ref_reason, ref_conclusion_id: problematic_reason.id, ref_reason_summary: "体内時計は､日の光を浴びることでリセットされるから") }
-  let!(:results_of_sleep_time_survey) { create(:ref_evidence, ref_reason_id: individual_differences_in_body_clock.id, ref_evidence_summary: "8155名のMSFsc調査結果") }
-  let!(:research_on_the_body_clock) { create(:ref_evidence, ref_reason_id: individual_differences_in_body_clock.id, ref_evidence_summary: "体内時計に関する研究") }
+  let!(:problematic_reason_and_evidence_connection) do
+    create(:ref_conclusion, agenda_board_id: about_early_bird.id, ref_conclusion_summary: "証拠が理由に適するものではない")
+  end
+  let(:individual_differences_in_body_clock) do
+    create(:ref_reason, ref_conclusion_id: problematic_reason.id, ref_reason_summary: "体内時計は､同年齢間においても個人差があり､一律ではないから")
+  end
+  let!(:resetting_the_body_clock) do
+    create(:ref_reason, ref_conclusion_id: problematic_reason.id, ref_reason_summary: "体内時計は､日の光を浴びることでリセットされるから")
+  end
+  let!(:results_of_sleep_time_survey) do
+    create(:ref_evidence, ref_reason_id: individual_differences_in_body_clock.id, ref_evidence_summary: "8155名のMSFsc調査結果")
+  end
+  let!(:research_on_the_body_clock) do
+    create(:ref_evidence, ref_reason_id: individual_differences_in_body_clock.id, ref_evidence_summary: "体内時計に関する研究")
+  end
 
   before do
     visit root_path

--- a/spec/system/refutations_spec.rb
+++ b/spec/system/refutations_spec.rb
@@ -11,10 +11,18 @@ RSpec.describe "Refutations", type: :system do
   let!(:research_of_dr_kelly) { create(:evidence, reason_id: misalignment_with_body_clock.id, evidence_summary: "ケリー博士の研究") }
 
   let(:problematic_reason) { create(:ref_conclusion, agenda_board_id: about_early_bird.id, ref_conclusion_summary: "理由部分に誤りがある") }
-  let(:individual_differences_in_body_clock) { create(:ref_reason, ref_conclusion_id: problematic_reason.id, ref_reason_summary: "体内時計は､同年齢間においても個人差があり､一律ではないから") }
-  let!(:resetting_the_body_clock) { create(:ref_reason, ref_conclusion_id: problematic_reason.id, ref_reason_summary: "体内時計は､日の光を浴びることでリセットされるから") }
-  let!(:results_of_sleep_time_survey) { create(:ref_evidence, ref_reason_id: individual_differences_in_body_clock.id, ref_evidence_summary: "8155名のMSFsc調査結果") }
-  let!(:research_on_the_body_clock) { create(:ref_evidence, ref_reason_id: individual_differences_in_body_clock.id, ref_evidence_summary: "体内時計に関する研究") }
+  let(:individual_differences_in_body_clock) do
+    create(:ref_reason, ref_conclusion_id: problematic_reason.id, ref_reason_summary: "体内時計は､同年齢間においても個人差があり､一律ではないから")
+  end
+  let!(:resetting_the_body_clock) do
+    create(:ref_reason, ref_conclusion_id: problematic_reason.id, ref_reason_summary: "体内時計は､日の光を浴びることでリセットされるから")
+  end
+  let!(:results_of_sleep_time_survey) do
+    create(:ref_evidence, ref_reason_id: individual_differences_in_body_clock.id, ref_evidence_summary: "8155名のMSFsc調査結果")
+  end
+  let!(:research_on_the_body_clock) do
+    create(:ref_evidence, ref_reason_id: individual_differences_in_body_clock.id, ref_evidence_summary: "体内時計に関する研究")
+  end
 
   before do
     visit root_path

--- a/spec/system/refutations_spec.rb
+++ b/spec/system/refutations_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+RSpec.describe "Refutations", type: :system do
+  let(:annie) { create(:user, name: "annie") }
+  let!(:about_early_bird) { create(:agenda_board, user_id: annie.id, agenda: "早起きは健康によいのか?", category: "自然科学") }
+
+  let(:bad_for_health) { create(:conclusion, agenda_board_id: about_early_bird.id, conclusion_summary: "健康に悪い") }
+  let(:misalignment_with_body_clock) { create(:reason, conclusion_id: bad_for_health.id, reason_summary: "人間の体内時計と噛み合っていないから") }
+  let!(:lack_of_sleep) { create(:reason, conclusion_id: bad_for_health.id, reason_summary: "睡眠不足になりやすいから") }
+  let!(:sleep_data) { create(:evidence, reason_id: misalignment_with_body_clock.id, evidence_summary: "世界中のあらゆる人々の睡眠データ") }
+  let!(:research_of_dr_kelly) { create(:evidence, reason_id: misalignment_with_body_clock.id, evidence_summary: "ケリー博士の研究") }
+
+  let(:problematic_reason) { create(:ref_conclusion, agenda_board_id: about_early_bird.id, ref_conclusion_summary: "理由部分に誤りがある") }
+  let(:individual_differences_in_body_clock) { create(:ref_reason, ref_conclusion_id: problematic_reason.id, ref_reason_summary: "体内時計は､同年齢間においても個人差があり､一律ではないから") }
+  let!(:resetting_the_body_clock) { create(:ref_reason, ref_conclusion_id: problematic_reason.id, ref_reason_summary: "体内時計は､日の光を浴びることでリセットされるから") }
+  let!(:results_of_sleep_time_survey) { create(:ref_evidence, ref_reason_id: individual_differences_in_body_clock.id, ref_evidence_summary: "8155名のMSFsc調査結果") }
+  let!(:research_on_the_body_clock) { create(:ref_evidence, ref_reason_id: individual_differences_in_body_clock.id, ref_evidence_summary: "体内時計に関する研究") }
+
+  before do
+    visit root_path
+    click_on "ログイン"
+    fill_in "メールアドレス", with: annie.email
+    fill_in "パスワード", with: annie.password
+    click_button "Log in"
+    click_on "#{annie.name}さんが作成した議題ボード"
+    click_on about_early_bird.agenda
+  end
+
+  context "主張下の｢新規反論作成｣ボタンをクリックして､新規反論作成ページにアクセスした時" do
+    before do
+      within ".argument" do
+        click_button "新規反論作成"
+      end
+    end
+
+    scenario "反論対象の主張を動的に確認できること" do
+      expect(page).to have_content bad_for_health.conclusion_summary
+      expect(page).to have_content bad_for_health.conclusion_detail
+
+      bad_for_health.reasons.all? do |reason|
+        expect(page).to have_content reason.reason_summary
+        expect(page).to have_content reason.reason_summary
+
+        reason.evidences.all? do |evidence|
+          expect(page).to have_content evidence.evidence_summary
+          expect(page).to have_content evidence.evidence_detail
+        end
+      end
+    end
+
+    describe "必要事項を入力して､｢新規反論を作成する｣ボタンを押すと" do
+      before do
+        fill_in "結論", with: "理由部分に誤りがある"
+        fill_in "結論詳細", with: "特になし"
+        fill_in "理由", with: "体内時計は､同年齢間においても個人差があり､一律ではないから"
+        fill_in "理由詳細", with: "特になし"
+        fill_in "証拠", with: "8155名のMSFsc調査結果"
+        fill_in "証拠詳細", with: "特になし"
+        click_button "新規反論を作成する"
+      end
+
+      scenario "新たな反論が作成されること" do
+        expect(page).to have_content "新規反論の作成に成功しました"
+      end
+
+      scenario "反論が所属する議題ボード詳細ページに遷移すること" do
+        expect(page).to have_current_path agenda_board_path(about_early_bird.id)
+      end
+    end
+  end
+
+  context "反論下の｢新規反論作成｣ボタンをクリックして､新規反論作成ページにアクセスした時" do
+    before do
+      within ".refutation" do
+        click_button "新規反論作成"
+      end
+    end
+
+    scenario "反論対象の反論を動的に確認できること" do
+      expect(page).to have_content problematic_reason.ref_conclusion_summary
+      expect(page).to have_content problematic_reason.ref_conclusion_detail
+
+      problematic_reason.ref_reasons.all? do |ref_reason|
+        expect(page).to have_content ref_reason.ref_reason_summary
+        expect(page).to have_content ref_reason.ref_reason_summary
+
+        ref_reason.ref_evidences.all? do |ref_evidence|
+          expect(page).to have_content ref_evidence.ref_evidence_summary
+          expect(page).to have_content ref_evidence.ref_evidence_detail
+        end
+      end
+    end
+
+    describe "必要事項を入力して､｢新規反論を作成する｣ボタンを押すと" do
+      before do
+        fill_in "結論", with: "証拠と理由が繋がっていない"
+        fill_in "結論詳細", with: "特になし"
+        fill_in "理由", with: "証拠にあげている調査は､同年齢を対象としたものではないから"
+        fill_in "理由詳細", with: "特になし"
+        fill_in "証拠", with: "提示された調査は､様々な年齢の人々(平均年齢は36.7歳)を対象にしたものなので､
+        ｢体内時計は同年齢間においても個人差がある｣という理由の証拠として適当ではない"
+        fill_in "証拠詳細", with: "特になし"
+        click_button "新規反論を作成する"
+      end
+
+      scenario "新たな反論が作成されること" do
+        expect(page).to have_content "新規反論の作成に成功しました"
+      end
+
+      scenario "反論が所属する議題ボード詳細ページに遷移すること" do
+        expect(page).to have_current_path agenda_board_path(about_early_bird.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 関連するチケット､Issue､プルリクエストのリンク

* #13

## なぜこの変更をするのか

* ユーザーが議題ボード詳細ページ上にある既存の主張や反論に対して､新規の反論を作成することを可能にし､主張と反論の2要素によって構成される議論環境を実現するため｡

## やったこと

* 既存の主張に対する新規反論(結論+理由+証拠)を作成する機能の実装
* 新規反論作成後､議題ボード詳細ページで､作成した反論を閲覧できるようにした(#12で追加した反論のサンプルは削除した)
* 主張のイメージカラーを薄紫色に､反論のイメージカラーを青色に変更した
* 既存の反論に対する新規反論(結論 + 理由 + 証拠)を作成する機能を実装
* 議題ボード詳細ページの反論の表示に関するシステムスペックを追加
* 新規反論作成ページのシステムスペックを実装

## やらないこと

* 議題ボード詳細ページと新規反論作成ページのjsPlumbを使用した処理に関するシステムスペックの実装
→ 実装の仕方が分かり次第､実装する｡


## 変更内容(議題ボード詳細ページへの機能追加と新規反論作成ページを新たに作成)


### before
議題ボード詳細ページ(create_new_refutationブランチをデブロイする直前)
![スクリーンショット 2023-05-12 10 10 29](https://github.com/tikuwabux/VisualDiscussion/assets/111355072/9cd5f2a6-e2f8-44ad-9846-9a7dc4d657cd)

### after
議題ボード詳細ページ(create_new_refutationブランチをデブロイした直後)
![スクリーンショット 2023-05-12 12 25 03](https://github.com/tikuwabux/VisualDiscussion/assets/111355072/6c6a3a7b-007d-48fe-abad-b8026b6b01b5)

### 1 議題ボード詳細ページで､既存の主張や反論下の｢新規反論作成｣ボタンを押すと､新規反論作成ページに遷移することができる
### 2 新規反論作成ページでは､反論対象の主張や反論を見ながら､反論を作成することができる｡
### 3 反論作成後は､元いた議題ボード詳細ページに遷移し､反論の閲覧やドラッグ､反論左上のソースエンドポイントから反論対象のターゲットエンドポイントに向けて接続線を引くことが可能になる｡


#### 既存の主張下の｢新規反論作成｣ボタンを押した場合の1~3

https://github.com/tikuwabux/VisualDiscussion/assets/111355072/e02b242d-199b-4935-bab2-18e9ab65c498




#### 既存の反論下の｢新規反論作成｣ボタンを押した場合の1~3


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/c229bc94-376f-48cd-9030-7585bbd4498f



## できるようになること（ユーザ目線）

1.  議題ボード詳細ページ上に表示されている､既存の主張や反論下の｢新規反論作成｣ボタンを押すと､新規反論作成ページに遷移することができる｡
2. 新規反論作成ページでは､反論対象の主張や反論を見ながら､反論を作成することができる｡
3. 反論作成後は､元いた議題ボード詳細ページに遷移し､反論の閲覧やドラッグ､反論左上のソースエンドポイントから反論対象のターゲットエンドポイントに向けて接続線を引くことが可能になる｡

## できなくなること（ユーザ目線）

* #12 で追加した反論のサンプルの閲覧および操作｡

## 動作確認

### 開発環境
#### 議題ボード詳細ページ
システムスペックを実装することで､追加したUIをテストした結果､すべてのテストをパスした｡
![スクリーンショット 2023-05-12 10 52 29](https://github.com/tikuwabux/VisualDiscussion/assets/111355072/f5ea31f2-69f6-45cc-b834-c0d18aad6227)

#### 新規反論作成ページ
上と同様の方法で､追加したUIをテストした結果､すべてのテストをパスした｡
![スクリーンショット 2023-05-12 10 55 42](https://github.com/tikuwabux/VisualDiscussion/assets/111355072/8a349a30-77af-46b4-8e5d-aa1de7de2173)

### 本番環境
Herokuアプリ上にて､手動で以下の動作確認を行ったところ､すべて問題なく動作した｡
1. - [x] 議題ボード詳細ページで､既存の主張や反論下の｢新規反論作成｣ボタンを押すと､新規反論作成ページに遷移することができるか｡
2. - [x] 新規反論作成ページでは､反論対象の主張や反論を見ながら､反論を作成することができるか｡
3. - [x] 反論作成後は､元いた議題ボード詳細ページに遷移し､反論の閲覧やドラッグ､反論左上のソースエンドポイントから反論対象のターゲットエンドポイントに向けて接続線を引くことができるか｡

## その他

* 参考サイト等
全体的な実装の流れは､#8  を参考にした｡
見た目のレイアウトは､#11  を参考にした｡
