### PR TITLE
議題ボード編集・削除機能を実装する

### DIFF
--- a/app/assets/stylesheets/agenda_boards.scss
+++ b/app/assets/stylesheets/agenda_boards.scss
@@ -123,3 +123,7 @@
   bottom: 100px;
   right: 150px;
 }
+
+td {
+  text-align: center;
+}

--- a/app/controllers/agenda_boards_controller.rb
+++ b/app/controllers/agenda_boards_controller.rb
@@ -39,6 +39,13 @@ class AgendaBoardsController < ApplicationController
     end
   end
 
+  def destroy
+    agenda_board = AgendaBoard.find(params[:id])
+    agenda_board.destroy
+    flash[:notice] = "議題ボードの削除に成功しました"
+    redirect_to agenda_boards_path
+  end
+
   private
 
   def agenda_board_params

--- a/app/controllers/agenda_boards_controller.rb
+++ b/app/controllers/agenda_boards_controller.rb
@@ -24,6 +24,21 @@ class AgendaBoardsController < ApplicationController
     @user_created_agenda_boards = AgendaBoard.where(user_id: current_user.id).order(created_at: :desc)
   end
 
+  def edit
+    @agenda_board = AgendaBoard.find(params[:id])
+  end
+
+  def update
+    agenda_board = AgendaBoard.find(params[:id])
+    if agenda_board.update(agenda_board_params)
+      flash[:notice] = "議題ボードの編集に成功しました"
+      redirect_to agenda_boards_path
+    else
+      flash[:notice] = "議題ボードの編集に失敗しました"
+      render "edit"
+    end
+  end
+
   private
 
   def agenda_board_params

--- a/app/views/agenda_boards/edit.html.erb
+++ b/app/views/agenda_boards/edit.html.erb
@@ -1,0 +1,21 @@
+<%= form_with model: @agenda_board, local: true do |form| %>
+  <table>
+    <tr>
+      <th>議題ボード編集フォーム</th>
+    </tr>
+    <tr>
+      <td><%= form.hidden_field :user_id, value: current_user.id %></td>
+    </tr>
+    <tr>
+      <th><%= form.label :agenda, "議題" %></th>
+      <td><%= form.text_field :agenda %></td>
+    </tr>
+    <tr>
+      <th><%= form.label :category, "カテゴリ" %></th>
+      <td><%= form.select :category, [ ["ビジネス", "ビジネス"], ["哲学", "哲学"], ["歴史", "歴史"], ["社会科学", "社会科学"], ["自然科学", "自然科学"], ["技術・工学", "技術・工学"], ["産業", "産業"], ["芸術・美術", "芸術・美術"], ["言語", "言語"], ["文学", "文学"], ["その他", "その他"]] %></td>
+    </tr>
+    <tr>
+      <th><%= form.submit "編集する"%></th>
+    </tr>
+  </table>
+<% end %>

--- a/app/views/agenda_boards/index.html.erb
+++ b/app/views/agenda_boards/index.html.erb
@@ -7,6 +7,7 @@
       <th>作成日</th>
       <th>編集</th>
       <th>削除</th>
+      <th>意見数</th>
     </tr>
   </thead>
   <tbody>
@@ -28,6 +29,9 @@
         <% else %>
           削除不可
         <% end %>
+      </td>
+      <td>
+        <%= user_created_agenda_board.conclusions.count + user_created_agenda_board.ref_conclusions.count %>
       </td>
     </tr>
     <% end %>

--- a/app/views/agenda_boards/index.html.erb
+++ b/app/views/agenda_boards/index.html.erb
@@ -11,7 +11,7 @@
   </thead>
   <tbody>
     <% @user_created_agenda_boards.each do |user_created_agenda_board| %>
-    <tr>
+    <tr id="agenda_board<%= user_created_agenda_board.id %>">
       <td><%= link_to user_created_agenda_board.agenda, agenda_board_path(user_created_agenda_board.id) %></td>
       <td><%= user_created_agenda_board.category %></td>
       <td><%= user_created_agenda_board.created_at %></td>

--- a/app/views/agenda_boards/index.html.erb
+++ b/app/views/agenda_boards/index.html.erb
@@ -5,6 +5,7 @@
       <th>議題</th>
       <th>カテゴリ</th>
       <th>作成日</th>
+      <th>編集</th>
     </tr>
   </thead>
   <tbody>
@@ -13,6 +14,13 @@
       <td><%= link_to user_created_agenda_board.agenda, agenda_board_path(user_created_agenda_board.id) %></td>
       <td><%= user_created_agenda_board.category %></td>
       <td><%= user_created_agenda_board.created_at %></td>
+      <td>
+        <% if user_created_agenda_board.conclusions == [] && user_created_agenda_board.ref_conclusions == [] %>
+          <%= link_to "編集", edit_agenda_board_path(user_created_agenda_board.id) %>
+        <% else %>
+          編集不可
+        <% end %>
+      </td>
     </tr>
     <% end %>
   </tbody>

--- a/app/views/agenda_boards/index.html.erb
+++ b/app/views/agenda_boards/index.html.erb
@@ -6,6 +6,7 @@
       <th>カテゴリ</th>
       <th>作成日</th>
       <th>編集</th>
+      <th>削除</th>
     </tr>
   </thead>
   <tbody>
@@ -19,6 +20,13 @@
           <%= link_to "編集", edit_agenda_board_path(user_created_agenda_board.id) %>
         <% else %>
           編集不可
+        <% end %>
+      </td>
+      <td>
+        <% if user_created_agenda_board.conclusions == [] && user_created_agenda_board.ref_conclusions == [] %>
+          <%= link_to "削除", agenda_board_path(user_created_agenda_board.id), method: :delete %>
+        <% else %>
+          削除不可
         <% end %>
       </td>
     </tr>

--- a/spec/system/agenda_boards_spec.rb
+++ b/spec/system/agenda_boards_spec.rb
@@ -101,6 +101,21 @@ RSpec.describe "AgendaBoards", type: :system do
       click_on about_early_bird.agenda
       expect(page).to have_current_path agenda_board_path(about_early_bird.id)
     end
+
+    context "議題ボードの作成者が現在ログイン中のユーザーであることに加え､その議題ボード中で意見が1つも作成されていないとき" do
+      scenario "｢編集｣リンクの表示を確認できること" do
+        within "#agenda_board#{about_chatbot.id}" do
+          expect(page).to have_link "編集"
+        end
+      end
+
+      scenario "｢編集｣リンクをクリックすると､議題ボード編集ページに遷移すること" do
+        within "#agenda_board#{about_chatbot.id}" do
+          click_on "編集"
+          expect(page).to have_current_path edit_agenda_board_path(about_chatbot.id)
+        end
+      end
+    end
   end
 
   describe "議題ボード詳細ページアクセス後" do
@@ -223,6 +238,26 @@ RSpec.describe "AgendaBoards", type: :system do
         end
         expect(page).not_to have_selector "#refutation#{problematic_reason_and_evidence_connection.id}"
       end
+    end
+  end
+
+  describe "議題ボード編集ページアクセス後､必要事項を入力して､｢編集する｣ボタンを押すと" do
+    before do
+      click_on "#{annie.name}さんが作成した議題ボード"
+      within "#agenda_board#{about_chatbot.id}" do
+        click_on "編集"
+      end
+      fill_in "議題", with: "チャットボットは今後のビジネスにどのような影響を与えるか?"
+      select "ビジネス", from: "agenda_board_category"
+      click_button "編集する"
+    end
+
+    scenario "議題ボードが編集されること" do
+      expect(page).to have_content "議題ボードの編集に成功しました"
+    end
+
+    scenario "ログインユーザーが作成した議題ボード一覧ページに遷移すること" do
+      expect(page).to have_current_path agenda_boards_path
     end
   end
 end

--- a/spec/system/agenda_boards_spec.rb
+++ b/spec/system/agenda_boards_spec.rb
@@ -97,6 +97,12 @@ RSpec.describe "AgendaBoards", type: :system do
       annie.agenda_boards.all? { |agenda_board| expect(page).to have_content agenda_board.category }
     end
 
+    scenario "議題ボードに投稿されている意見数の一覧を動的に確認できる" do
+      annie.agenda_boards.all? do |agenda_board|
+        expect(page).to have_content agenda_board.conclusions.count + agenda_board.ref_conclusions.count
+      end
+    end
+
     scenario "議題名をクリックすると､その議題ボードの詳細ページに遷移すること" do
       click_on about_early_bird.agenda
       expect(page).to have_current_path agenda_board_path(about_early_bird.id)

--- a/spec/system/agenda_boards_spec.rb
+++ b/spec/system/agenda_boards_spec.rb
@@ -115,6 +115,19 @@ RSpec.describe "AgendaBoards", type: :system do
           expect(page).to have_current_path edit_agenda_board_path(about_chatbot.id)
         end
       end
+
+      scenario "｢削除｣リンクの表示を確認できること" do
+        within "#agenda_board#{about_chatbot.id}" do
+          expect(page).to have_link "削除"
+        end
+      end
+
+      scenario "｢削除｣リンクをクリックすると､議題ボードが削除されること" do
+        within "#agenda_board#{about_chatbot.id}" do
+          click_on "削除"
+        end
+        expect(page).to have_content "議題ボードの削除に成功しました"
+      end
     end
   end
 


### PR DESCRIPTION
## 関連するチケット､Issue､プルリクエストのリンク

* #18 

## なぜこの変更をするのか

*ユーザーが､意図しない議題ボードを作ってしまったときに､自分で修正できるようにするため｡

## やったこと

1. 議題ボード編集機能を実装した
2. 議題ボード削除機能を実装した
3. 議題ボード一覧ページで意見数も表示するようにした
## やらないこと

* 無し

## 変更内容

### 1. 議題ボード編集機能
#### before
![スクリーンショット 2023-06-10 21 02 40](https://github.com/tikuwabux/VisualDiscussion/assets/111355072/140e0cea-5a95-4b60-933a-e7da02ac0020)


#### after

https://github.com/tikuwabux/VisualDiscussion/assets/111355072/841687d6-37b0-4ce2-a1c0-60398235c952



### 2. 議題ボード削除機能

#### before
![スクリーンショット 2023-06-10 21 02 40](https://github.com/tikuwabux/VisualDiscussion/assets/111355072/890bdb9c-667d-4a63-880a-1079f73e04a5)

#### after

https://github.com/tikuwabux/VisualDiscussion/assets/111355072/bd92a937-849d-4e7d-8c51-1e0b93b8a90c

### 3. 議題ボード一覧ページでの意見数表示
#### before
![スクリーンショット 2023-06-10 21 02 40](https://github.com/tikuwabux/VisualDiscussion/assets/111355072/890bdb9c-667d-4a63-880a-1079f73e04a5)

#### after
![スクリーンショット 2023-06-11 9 57 01](https://github.com/tikuwabux/VisualDiscussion/assets/111355072/00503c4a-a5c2-4080-ab2e-5972ede7c9b7)

## できるようになること（ユーザ目線）

1. 自身が作成した議題ボードのうち､まだ意見が1つも投稿されていない議題ボードに関してのみ議題やカテゴリの編集を行うこと
2. 自身が作成した議題ボードのうち､まだ意見が1つも投稿されていない議題ボードに関してのみ､削除を行うこと
3. 議題ボードごとの意見数を確認することができるので､盛り上がっている議題ボードが一目で分かる｡

## できなくなること（ユーザ目線）

* 無し

## 動作確認

### 開発環境下
#### 議題ボード編集機能
システムスペックを実装することで､追加したUIをテストした結果､すべてのテストをパスした｡
![スクリーンショット 2023-06-11 9 17 46](https://github.com/tikuwabux/VisualDiscussion/assets/111355072/24a81650-b4bb-4626-89cf-6d8f61eb1d67)


#### 議題ボード削除機能
上と同様の方法で､追加したUIをテストした結果､すべてのテストをパスした｡
![スクリーンショット 2023-06-11 9 21 02](https://github.com/tikuwabux/VisualDiscussion/assets/111355072/578608e7-3106-41b8-9cda-b87206413340)


#### 議題ボード一覧ページでの意見数表示
上と同様の方法で､追加したUIをテストした結果､すべてのテストをパスした｡
![スクリーンショット 2023-06-11 9 22 21](https://github.com/tikuwabux/VisualDiscussion/assets/111355072/4e955073-322f-40a7-b703-e4d1e6b427e2)


## その他
無し