### PR TITLE
意見の位置情報や意見間の接続線情報の保存場所をローカルストレージからDBへ移行する

### DIFF
--- a/app/controllers/opinion_connections_controller.rb
+++ b/app/controllers/opinion_connections_controller.rb
@@ -1,0 +1,57 @@
+class OpinionConnectionsController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: [:create, :destroy]
+
+  def create
+    if OpinionConnection.find_by(source_id: opinion_connection_params[:source_id])
+      update
+      return
+    end
+
+    opinion_connection = OpinionConnection.new(opinion_connection_params)
+    if opinion_connection.save
+      render json: { message: "意見間の接続線情報を保存しました" }
+    else
+      render json: { error: "意見間の接続線情報の保存に失敗しました" }, status: :unprocessable_entity
+    end
+  end
+
+
+  def update
+    opinion_connection = OpinionConnection.find_by(source_id: opinion_connection_params[:source_id])
+
+    if opinion_connection.update(opinion_connection_params)
+      render json: { message: "意見間の接続線情報を更新しました" }
+    else
+      render json: { error: "意見間の接続線情報の更新に失敗しました" }, status: :unprocessable_entity
+    end
+
+  end
+
+  def index
+    opinion_connections = OpinionConnection.all
+    response_data = opinion_connections.map do |opinion_connection|
+      {
+        source_id: opinion_connection.source_id,
+        target_id: opinion_connection.target_id,
+      }
+    end
+
+    render json: { opinion_connections: response_data }
+  end
+
+  def destroy
+    opinion_connection = OpinionConnection.find_by(opinion_connection_params)
+    if opinion_connection
+      opinion_connection.destroy
+      render json: { message: "意見間の接続線情報を削除しました" }
+    else
+      render json: { error: "意見間の接続線情報の削除に失敗しました" }, status: :not_found
+    end
+  end
+
+  private
+
+  def opinion_connection_params
+    params.require(:opinion_connection).permit(:source_id, :target_id)
+  end
+end

--- a/app/controllers/opinion_connections_controller.rb
+++ b/app/controllers/opinion_connections_controller.rb
@@ -1,43 +1,40 @@
 class OpinionConnectionsController < ApplicationController
   skip_before_action :verify_authenticity_token, only: [:create, :destroy]
+  before_action :find_opinion_connection, only: [:create, :update, :destroy]
 
   def create
-    if OpinionConnection.find_by(source_id: opinion_connection_params[:source_id])
+    if @opinion_connection
       update
       return
     end
 
     opinion_connection = OpinionConnection.new(opinion_connection_params)
     if opinion_connection.save
-      render json: { success_message: "意見間の接続線情報を保存しました" }
+      render_success('意見間の接続線情報を保存しました')
     else
-      render json: { error_message: "意見間の接続線情報を保存できませんでした" }, status: :unprocessable_entity
+      render_error("意見間の接続線情報を保存できませんでした")
     end
   end
 
   def update
-    opinion_connection = OpinionConnection.find_by(source_id: opinion_connection_params[:source_id])
-
-    if opinion_connection.update(opinion_connection_params)
-      render json: { success_message: "意見間の接続線情報を更新しました" }
+    if @opinion_connection.update(opinion_connection_params)
+      render_success("意見間の接続線情報を更新しました")
     else
-      render json: { error_message: "意見間の接続線情報を更新できませんでした" }, status: :unprocessable_entity
+      render_error("意見間の接続線情報を更新できませんでした")
     end
   end
 
   def destroy
-    opinion_connection = OpinionConnection.find_by(opinion_connection_params)
-    if opinion_connection
-      opinion_connection.destroy
-      render json: { success_message: "意見間の接続線情報を削除しました" }
+    if @opinion_connection.destroy
+      render_success("意見間の接続線情報を削除しました")
     else
-      render json: { error_message: "意見間の接続線情報を削除できませんでした" }, status: :not_found
+      render_error("意見間の接続線情報を削除できませんでした")
     end
   end
 
   def index
     opinion_connections = OpinionConnection.all
-    if opinion_connections
+    if opinion_connections.present?
       response_data = opinion_connections.map do |opinion_connection|
         {
           source_id: opinion_connection.source_id,
@@ -46,7 +43,7 @@ class OpinionConnectionsController < ApplicationController
       end
       render json: { opinion_connections: response_data }
     else
-      render json: { error_message: '意見間の接続線情報を取得できませんでした' }, status: :not_found
+      render_error('意見間の接続線情報を取得できませんでした')
     end
   end
 
@@ -54,5 +51,17 @@ class OpinionConnectionsController < ApplicationController
 
   def opinion_connection_params
     params.require(:opinion_connection).permit(:source_id, :target_id)
+  end
+
+  def find_opinion_connection
+    @opinion_connection = OpinionConnection.find_by(source_id: opinion_connection_params[:source_id])
+  end
+
+  def render_success(success_message)
+    render json: { success_message: success_message }
+  end
+
+  def render_error(error_message)
+    render json: { error_message: error_message }, status: 500
   end
 end

--- a/app/controllers/opinion_connections_controller.rb
+++ b/app/controllers/opinion_connections_controller.rb
@@ -9,9 +9,9 @@ class OpinionConnectionsController < ApplicationController
 
     opinion_connection = OpinionConnection.new(opinion_connection_params)
     if opinion_connection.save
-      render json: { message: "意見間の接続線情報を保存しました" }
+      render json: { success_message: "意見間の接続線情報を保存しました" }
     else
-      render json: { error: "意見間の接続線情報を保存できませんでした" }, status: :unprocessable_entity
+      render json: { error_message: "意見間の接続線情報を保存できませんでした" }, status: :unprocessable_entity
     end
   end
 
@@ -19,9 +19,9 @@ class OpinionConnectionsController < ApplicationController
     opinion_connection = OpinionConnection.find_by(source_id: opinion_connection_params[:source_id])
 
     if opinion_connection.update(opinion_connection_params)
-      render json: { message: "意見間の接続線情報を更新しました" }
+      render json: { success_message: "意見間の接続線情報を更新しました" }
     else
-      render json: { error: "意見間の接続線情報を更新できませんでした" }, status: :unprocessable_entity
+      render json: { error_message: "意見間の接続線情報を更新できませんでした" }, status: :unprocessable_entity
     end
   end
 
@@ -29,9 +29,9 @@ class OpinionConnectionsController < ApplicationController
     opinion_connection = OpinionConnection.find_by(opinion_connection_params)
     if opinion_connection
       opinion_connection.destroy
-      render json: { message: "意見間の接続線情報を削除しました" }
+      render json: { success_message: "意見間の接続線情報を削除しました" }
     else
-      render json: { error: "意見間の接続線情報を削除できませんでした" }, status: :not_found
+      render json: { error_message: "意見間の接続線情報を削除できませんでした" }, status: :not_found
     end
   end
 
@@ -46,7 +46,7 @@ class OpinionConnectionsController < ApplicationController
       end
       render json: { opinion_connections: response_data }
     else
-      render json: { error: '意見間の接続線情報を取得できませんでした' }, status: :not_found
+      render json: { error_message: '意見間の接続線情報を取得できませんでした' }, status: :not_found
     end
   end
 

--- a/app/controllers/opinion_connections_controller.rb
+++ b/app/controllers/opinion_connections_controller.rb
@@ -11,10 +11,9 @@ class OpinionConnectionsController < ApplicationController
     if opinion_connection.save
       render json: { message: "意見間の接続線情報を保存しました" }
     else
-      render json: { error: "意見間の接続線情報の保存に失敗しました" }, status: :unprocessable_entity
+      render json: { error: "意見間の接続線情報を保存できませんでした" }, status: :unprocessable_entity
     end
   end
-
 
   def update
     opinion_connection = OpinionConnection.find_by(source_id: opinion_connection_params[:source_id])
@@ -22,21 +21,8 @@ class OpinionConnectionsController < ApplicationController
     if opinion_connection.update(opinion_connection_params)
       render json: { message: "意見間の接続線情報を更新しました" }
     else
-      render json: { error: "意見間の接続線情報の更新に失敗しました" }, status: :unprocessable_entity
+      render json: { error: "意見間の接続線情報を更新できませんでした" }, status: :unprocessable_entity
     end
-
-  end
-
-  def index
-    opinion_connections = OpinionConnection.all
-    response_data = opinion_connections.map do |opinion_connection|
-      {
-        source_id: opinion_connection.source_id,
-        target_id: opinion_connection.target_id,
-      }
-    end
-
-    render json: { opinion_connections: response_data }
   end
 
   def destroy
@@ -45,7 +31,22 @@ class OpinionConnectionsController < ApplicationController
       opinion_connection.destroy
       render json: { message: "意見間の接続線情報を削除しました" }
     else
-      render json: { error: "意見間の接続線情報の削除に失敗しました" }, status: :not_found
+      render json: { error: "意見間の接続線情報を削除できませんでした" }, status: :not_found
+    end
+  end
+
+  def index
+    opinion_connections = OpinionConnection.all
+    if opinion_connections
+      response_data = opinion_connections.map do |opinion_connection|
+        {
+          source_id: opinion_connection.source_id,
+          target_id: opinion_connection.target_id,
+        }
+      end
+      render json: { opinion_connections: response_data }
+    else
+      render json: { error: '意見間の接続線情報を取得できませんでした' }, status: :not_found
     end
   end
 

--- a/app/controllers/opinion_positions_controller.rb
+++ b/app/controllers/opinion_positions_controller.rb
@@ -1,31 +1,20 @@
 class OpinionPositionsController < ApplicationController
   skip_before_action :verify_authenticity_token, only: [:create]
+  before_action :find_opinion_position, only: [:create, :update]
 
   def create
-    if OpinionPosition.find_by(argument_id: opinion_position_params[:argument_id]) or OpinionPosition.find_by(refutation_id: opinion_position_params[:refutation_id])
+    if @opinion_position
       update
-      return
-    end
-
-    opinion_position = OpinionPosition.new(opinion_position_params)
-
-    if opinion_position.save
-      render json: { message: 'Opinion position saved successfully' }, status: :created
     else
-      render json: { errors: opinion_position.errors.full_messages }, status: :unprocessable_entity
+      create_new_opinion_position
     end
   end
 
   def update
-    if opinion_position = OpinionPosition.find_by(argument_id: opinion_position_params[:argument_id])
+    if @opinion_position.update(opinion_position_params)
+      render_success('意見の位置を更新しました')
     else
-      opinion_position = OpinionPosition.find_by(refutation_id: opinion_position_params[:refutation_id])
-    end
-
-    if opinion_position.update(opinion_position_params)
-      render json: { message: 'Opinion position updated successfully' }, status: :ok
-    else
-      render json: { errors: opinion_position.errors.full_messages }, status: :unprocessable_entity
+      render_error(opinion_position.errors.full_messages)
     end
   end
 
@@ -47,5 +36,27 @@ class OpinionPositionsController < ApplicationController
 
   def opinion_position_params
     params.require(:opinion_position).permit(:argument_id, :refutation_id, :left, :top)
+  end
+
+  def find_opinion_position
+    @opinion_position = OpinionPosition.find_by(argument_id: opinion_position_params[:argument_id]) ||
+                        OpinionPosition.find_by(refutation_id: opinion_position_params[:refutation_id])
+  end
+
+  def create_new_opinion_position
+    opinion_position = OpinionPosition.new(opinion_position_params)
+    if opinion_position.save
+      render_success('意見の位置を保存しました')
+    else
+      render_error(opinion_position.errors.full_messages)
+    end
+  end
+
+  def render_success(message)
+    render json: { message: message }
+  end
+
+  def render_error(errors)
+    render json: { errors: errors }
   end
 end

--- a/app/controllers/opinion_positions_controller.rb
+++ b/app/controllers/opinion_positions_controller.rb
@@ -12,24 +12,28 @@ class OpinionPositionsController < ApplicationController
 
   def update
     if @opinion_position.update(opinion_position_params)
-      render_success('意見の位置を更新しました')
+      render_success('意見の位置情報を更新しました')
     else
-      render_error(opinion_position.errors.full_messages)
+      render_error('意見の位置情報を更新できませんでした')
     end
   end
 
   def index
     opinion_positions = OpinionPosition.all
-    response_data = opinion_positions.map do |position|
-      {
-        argument_id: position.argument_id,
-        refutation_id: position.refutation_id,
-        left: position.left,
-        top: position.top,
-      }
-    end
+    if opinion_positions
+      response_data = opinion_positions.map do |position|
+        {
+          argument_id: position.argument_id,
+          refutation_id: position.refutation_id,
+          left: position.left,
+          top: position.top,
+        }
+      end
 
-    render json: { opinion_positions: response_data }
+      render json: { opinion_positions: response_data }
+    else
+      render_error('意見の位置情報を取得できませんでした')
+    end
   end
 
   private
@@ -46,9 +50,9 @@ class OpinionPositionsController < ApplicationController
   def create_new_opinion_position
     opinion_position = OpinionPosition.new(opinion_position_params)
     if opinion_position.save
-      render_success('意見の位置を保存しました')
+      render_success('意見の位置情報を保存しました')
     else
-      render_error(opinion_position.errors.full_messages)
+      render_error('意見の位置情報を保存できませんでした')
     end
   end
 
@@ -56,7 +60,7 @@ class OpinionPositionsController < ApplicationController
     render json: { message: message }
   end
 
-  def render_error(errors)
-    render json: { errors: errors }
+  def render_error(error)
+    render json: { error: error }, status: 500
   end
 end

--- a/app/controllers/opinion_positions_controller.rb
+++ b/app/controllers/opinion_positions_controller.rb
@@ -20,7 +20,7 @@ class OpinionPositionsController < ApplicationController
 
   def index
     opinion_positions = OpinionPosition.all
-    if opinion_positions
+    if opinion_positions.present?
       response_data = opinion_positions.map do |position|
         {
           argument_id: position.argument_id,

--- a/app/controllers/opinion_positions_controller.rb
+++ b/app/controllers/opinion_positions_controller.rb
@@ -56,11 +56,11 @@ class OpinionPositionsController < ApplicationController
     end
   end
 
-  def render_success(message)
-    render json: { message: message }
+  def render_success(success_message)
+    render json: { success_message: success_message }
   end
 
-  def render_error(error)
-    render json: { error: error }, status: 500
+  def render_error(error_message)
+    render json: { error_message: error_message }, status: 500
   end
 end

--- a/app/controllers/opinion_positions_controller.rb
+++ b/app/controllers/opinion_positions_controller.rb
@@ -2,27 +2,30 @@ class OpinionPositionsController < ApplicationController
   skip_before_action :verify_authenticity_token, only: [:create]
 
   def create
-    if OpinionPosition.find_by(argument_id: argument_position_params[:argument_id])
+    if OpinionPosition.find_by(argument_id: opinion_position_params[:argument_id]) or OpinionPosition.find_by(refutation_id: opinion_position_params[:refutation_id])
       update
       return
     end
 
-    argument_position = OpinionPosition.new(argument_position_params)
+    opinion_position = OpinionPosition.new(opinion_position_params)
 
-    if argument_position.save
-      render json: { message: 'Argument position saved successfully' }, status: :created
+    if opinion_position.save
+      render json: { message: 'Opinion position saved successfully' }, status: :created
     else
-      render json: { errors: argument_position.errors.full_messages }, status: :unprocessable_entity
+      render json: { errors: opinion_position.errors.full_messages }, status: :unprocessable_entity
     end
   end
 
   def update
-    argument_position = OpinionPosition.find_by(argument_id: argument_position_params[:argument_id])
-
-    if argument_position.update(argument_position_params)
-      render json: { message: 'Argument position updated successfully' }, status: :ok
+    if opinion_position = OpinionPosition.find_by(argument_id: opinion_position_params[:argument_id])
     else
-      render json: { errors: argument_position.errors.full_messages }, status: :unprocessable_entity
+      opinion_position = OpinionPosition.find_by(refutation_id: opinion_position_params[:refutation_id])
+    end
+
+    if opinion_position.update(opinion_position_params)
+      render json: { message: 'Opinion position updated successfully' }, status: :ok
+    else
+      render json: { errors: opinion_position.errors.full_messages }, status: :unprocessable_entity
     end
   end
 
@@ -37,12 +40,12 @@ class OpinionPositionsController < ApplicationController
       }
     end
 
-    render json: { argument_positions: response_data }
+    render json: { opinion_positions: response_data }
   end
 
   private
 
-  def argument_position_params
-    params.require(:argument_position).permit(:argument_id, :refutation_id, :left, :top)
+  def opinion_position_params
+    params.require(:opinion_position).permit(:argument_id, :refutation_id, :left, :top)
   end
 end

--- a/app/controllers/opinion_positions_controller.rb
+++ b/app/controllers/opinion_positions_controller.rb
@@ -5,8 +5,14 @@ class OpinionPositionsController < ApplicationController
   def create
     if @opinion_position
       update
+      return
+    end
+
+    opinion_position = OpinionPosition.new(opinion_position_params)
+    if opinion_position.save
+      render_success('意見の位置情報を保存しました')
     else
-      create_new_opinion_position
+      render_error('意見の位置情報を保存できませんでした')
     end
   end
 
@@ -45,15 +51,6 @@ class OpinionPositionsController < ApplicationController
   def find_opinion_position
     @opinion_position = OpinionPosition.find_by(argument_id: opinion_position_params[:argument_id]) ||
                         OpinionPosition.find_by(refutation_id: opinion_position_params[:refutation_id])
-  end
-
-  def create_new_opinion_position
-    opinion_position = OpinionPosition.new(opinion_position_params)
-    if opinion_position.save
-      render_success('意見の位置情報を保存しました')
-    else
-      render_error('意見の位置情報を保存できませんでした')
-    end
   end
 
   def render_success(success_message)

--- a/app/controllers/opinion_positions_controller.rb
+++ b/app/controllers/opinion_positions_controller.rb
@@ -1,0 +1,2 @@
+class OpinionPositionsController < ApplicationController
+end

--- a/app/controllers/opinion_positions_controller.rb
+++ b/app/controllers/opinion_positions_controller.rb
@@ -1,2 +1,48 @@
 class OpinionPositionsController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: [:create]
+
+  def create
+    if OpinionPosition.find_by(argument_id: argument_position_params[:argument_id])
+      update
+      return
+    end
+
+    argument_position = OpinionPosition.new(argument_position_params)
+
+    if argument_position.save
+      render json: { message: 'Argument position saved successfully' }, status: :created
+    else
+      render json: { errors: argument_position.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    argument_position = OpinionPosition.find_by(argument_id: argument_position_params[:argument_id])
+
+    if argument_position.update(argument_position_params)
+      render json: { message: 'Argument position updated successfully' }, status: :ok
+    else
+      render json: { errors: argument_position.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def index
+    opinion_positions = OpinionPosition.all
+    response_data = opinion_positions.map do |position|
+      {
+        argument_id: position.argument_id,
+        refutation_id: position.refutation_id,
+        left: position.left,
+        top: position.top,
+      }
+    end
+
+    render json: { argument_positions: response_data }
+  end
+
+  private
+
+  def argument_position_params
+    params.require(:argument_position).permit(:argument_id, :refutation_id, :left, :top)
+  end
 end

--- a/app/javascript/packs/agenda_board.js
+++ b/app/javascript/packs/agenda_board.js
@@ -27,8 +27,10 @@ jsPlumb.ready(function() {
           }
         });
         // 遅延させないと理由証拠間のレイアウトが乱れる
-        setTimeout(arrangeArgumentLayout, 10);
-        setTimeout(restoreOpinionConnections, 10);
+        setTimeout(function() {
+          arrangeArgumentLayout();
+          restoreOpinionConnections();
+        }, 10);
       },
       error: function(xhr, status, error) {
         console.error(xhr.responseJSON.error_message);
@@ -216,9 +218,11 @@ jsPlumb.ready(function() {
           }
         });
         // 遅延させないとレイアウトが乱れる
-        setTimeout(arrangeRefutationLayout, 10);
-        setTimeout(setSourceEndpoint, 10);
-        setTimeout(restoreOpinionConnections, 10);
+        setTimeout(function() {
+          arrangeRefutationLayout();
+          setSourceEndpoint();
+          restoreOpinionConnections();
+        }, 10);
       },
       error: function(xhr, status, error) {
         console.error(xhr.responseJSON.error_message);

--- a/app/javascript/packs/agenda_board.js
+++ b/app/javascript/packs/agenda_board.js
@@ -31,7 +31,7 @@ jsPlumb.ready(function() {
         setTimeout(restoreOpinionConnections, 10);
       },
       error: function(xhr, status, error) {
-        console.error('主張の位置情報の取得エラー:', error);
+        console.error(xhr.responseJSON.error);
       }
     });
 
@@ -54,7 +54,7 @@ jsPlumb.ready(function() {
           console.log(response.message)
         },
         error: function(xhr, status, error) {
-          console.error('主張の位置情報の保存エラー:', error);
+          console.error(xhr.responseJSON.error);
         }
       });
     }
@@ -221,7 +221,7 @@ jsPlumb.ready(function() {
         setTimeout(restoreOpinionConnections, 10);
       },
       error: function(xhr, status, error) {
-        console.error('反論の位置情報の取得エラー:', error);
+        console.error(xhr.responseJSON.error);
       }
     });
 
@@ -254,7 +254,7 @@ jsPlumb.ready(function() {
           console.log(response.message)
         },
         error: function(xhr, status, error) {
-          console.error('反論の位置情報の保存エラー:', error);
+          console.error(xhr.responseJSON.error);
         }
       });
     }

--- a/app/javascript/packs/agenda_board.js
+++ b/app/javascript/packs/agenda_board.js
@@ -220,7 +220,7 @@ jsPlumb.ready(function() {
         // 遅延させないとレイアウトが乱れる
         setTimeout(function() {
           arrangeRefutationLayout();
-          setSourceEndpoint();
+          setSourceEndpoint(refutation_id);
           restoreOpinionConnections();
         }, 10);
       },
@@ -229,14 +229,19 @@ jsPlumb.ready(function() {
       }
     });
 
-    // 反論の左上にソースエンドポイントを設置する関数
-    function setSourceEndpoint() {
-      jsPlumb.addEndpoint(`${refutation_id}`, {
+    // 反論の左上にソースエンドポイントを1つだけ設置する関数
+    function setSourceEndpoint(refutation_id) {
+      const sourceEndpoints = jsPlumb.getEndpoints(refutation_id, { source: true });
+      if (sourceEndpoints.length > 0) {
+        jsPlumb.deleteEndpoint(sourceEndpoints[0]);
+      }
+
+      jsPlumb.addEndpoint(refutation_id, {
         endpoint: "Dot",
         anchor: "TopLeft",
         isSource: true,
         connectionType: "red-connection"
-      })
+      });
     }
 
     // 反論のドラッグ終了後の位置をopinion_positionsテーブルに保存する関数

--- a/app/javascript/packs/agenda_board.js
+++ b/app/javascript/packs/agenda_board.js
@@ -229,7 +229,7 @@ jsPlumb.ready(function() {
 
     // 反論の左上にソースエンドポイントを1つだけ設置する関数
     function setSourceEndpoint(refutation_id) {
-      const sourceEndpoints = jsPlumb.getEndpoints(refutation_id, { source: true });
+      const sourceEndpoints = jsPlumb.getEndpoints(refutation_id);
       if (sourceEndpoints.length > 0) {
         jsPlumb.deleteEndpoint(sourceEndpoints[0]);
       }

--- a/app/javascript/packs/agenda_board.js
+++ b/app/javascript/packs/agenda_board.js
@@ -219,8 +219,8 @@ jsPlumb.ready(function() {
         });
         // 遅延させないとレイアウトが乱れる
         setTimeout(arrangeRefutationLayout, 10);
-        setTimeout(setSourceEndpoint(refutation_id), 20);
-        setTimeout(restoreOpinionConnections, 1000);
+        setTimeout(setSourceEndpoint(refutation_id), 50);
+        setTimeout(restoreOpinionConnections, 100);
       },
       error: function(xhr, status, error) {
         console.error(xhr.responseJSON.error_message);

--- a/app/javascript/packs/agenda_board.js
+++ b/app/javascript/packs/agenda_board.js
@@ -218,11 +218,9 @@ jsPlumb.ready(function() {
           }
         });
         // 遅延させないとレイアウトが乱れる
-        setTimeout(function() {
-          arrangeRefutationLayout();
-          setSourceEndpoint(refutation_id);
-          restoreOpinionConnections();
-        }, 10);
+        setTimeout(arrangeRefutationLayout, 10);
+        setTimeout(setSourceEndpoint(refutation_id), 20);
+        setTimeout(restoreOpinionConnections, 30);
       },
       error: function(xhr, status, error) {
         console.error(xhr.responseJSON.error_message);

--- a/app/javascript/packs/agenda_board.js
+++ b/app/javascript/packs/agenda_board.js
@@ -220,7 +220,7 @@ jsPlumb.ready(function() {
         // 遅延させないとレイアウトが乱れる
         setTimeout(arrangeRefutationLayout, 10);
         setTimeout(setSourceEndpoint(refutation_id), 20);
-        setTimeout(restoreOpinionConnections, 30);
+        setTimeout(restoreOpinionConnections, 1000);
       },
       error: function(xhr, status, error) {
         console.error(xhr.responseJSON.error_message);

--- a/app/javascript/packs/agenda_board.js
+++ b/app/javascript/packs/agenda_board.js
@@ -428,7 +428,7 @@ jsPlumb.ready(function() {
         console.log(response.message);
       },
       error: function(xhr, status, error) {
-        console.error(error);
+        console.error(xhr.responseJSON.error);
       }
     });
   }
@@ -451,7 +451,7 @@ jsPlumb.ready(function() {
         console.log(response.message);
       },
       error: function(xhr, status, error) {
-        console.error(error);
+        console.error(xhr.responseJSON.error);
       }
     });
   }
@@ -480,6 +480,9 @@ jsPlumb.ready(function() {
             });
           });
         }
+      },
+      error: function(xhr, status, error) {
+        console.error(xhr.responseJSON.error);
       }
     });
   }

--- a/app/javascript/packs/agenda_board.js
+++ b/app/javascript/packs/agenda_board.js
@@ -31,7 +31,7 @@ jsPlumb.ready(function() {
         setTimeout(restoreOpinionConnections, 10);
       },
       error: function(xhr, status, error) {
-        console.error(xhr.responseJSON.error);
+        console.error(xhr.responseJSON.error_message);
       }
     });
 
@@ -51,10 +51,10 @@ jsPlumb.ready(function() {
           }
         },
         success: function(response) {
-          console.log(response.message)
+          console.log(response.success_message)
         },
         error: function(xhr, status, error) {
-          console.error(xhr.responseJSON.error);
+          console.error(xhr.responseJSON.error_message);
         }
       });
     }
@@ -221,7 +221,7 @@ jsPlumb.ready(function() {
         setTimeout(restoreOpinionConnections, 10);
       },
       error: function(xhr, status, error) {
-        console.error(xhr.responseJSON.error);
+        console.error(xhr.responseJSON.error_message);
       }
     });
 
@@ -251,10 +251,10 @@ jsPlumb.ready(function() {
           }
         },
         success: function(response) {
-          console.log(response.message)
+          console.log(response.success_message)
         },
         error: function(xhr, status, error) {
-          console.error(xhr.responseJSON.error);
+          console.error(xhr.responseJSON.error_message);
         }
       });
     }
@@ -425,10 +425,10 @@ jsPlumb.ready(function() {
         }
       },
       success: function(response) {
-        console.log(response.message);
+        console.log(response.success_message);
       },
       error: function(xhr, status, error) {
-        console.error(xhr.responseJSON.error);
+        console.error(xhr.responseJSON.error_message);
       }
     });
   }
@@ -448,10 +448,10 @@ jsPlumb.ready(function() {
         }
       },
       success: function(response) {
-        console.log(response.message);
+        console.log(response.success_message);
       },
       error: function(xhr, status, error) {
-        console.error(xhr.responseJSON.error);
+        console.error(xhr.responseJSON.error_message);
       }
     });
   }
@@ -482,7 +482,7 @@ jsPlumb.ready(function() {
         }
       },
       error: function(xhr, status, error) {
-        console.error(xhr.responseJSON.error);
+        console.error(xhr.responseJSON.error_message);
       }
     });
   }

--- a/app/javascript/packs/agenda_board.js
+++ b/app/javascript/packs/agenda_board.js
@@ -30,7 +30,7 @@ jsPlumb.ready(function() {
         setTimeout(arrangeArgumentLayout, 10);
       },
       error: function(xhr, status, error) {
-        console.error('Error retrieving argument positions:', error);
+        console.error('主張の位置情報の取得エラー:', error);
       }
     });
 
@@ -53,7 +53,7 @@ jsPlumb.ready(function() {
           console.log(response.message)
         },
         error: function(xhr, status, error) {
-          console.error('Error saving argument position:', error);
+          console.error('主張の位置情報の保存エラー:', error);
         }
       });
     }
@@ -219,7 +219,7 @@ jsPlumb.ready(function() {
         setTimeout(setSourceEndpoint, 10);
       },
       error: function(xhr, status, error) {
-        console.error('Error retrieving refutation positions:', error);
+        console.error('反論の位置情報の取得エラー:', error);
       }
     });
 
@@ -252,7 +252,7 @@ jsPlumb.ready(function() {
           console.log(response.message)
         },
         error: function(xhr, status, error) {
-          console.error('Error saving refutation position:', error);
+          console.error('反論の位置情報の保存エラー:', error);
         }
       });
     }

--- a/app/javascript/packs/agenda_board.js
+++ b/app/javascript/packs/agenda_board.js
@@ -227,13 +227,8 @@ jsPlumb.ready(function() {
       }
     });
 
-    // 反論の左上にソースエンドポイントを1つだけ設置する関数
+    // 反論の左上にソースエンドポイントを設置する関数
     function setSourceEndpoint(refutation_id) {
-      const sourceEndpoints = jsPlumb.getEndpoints(refutation_id);
-      if (sourceEndpoints.length > 0) {
-        jsPlumb.deleteEndpoint(sourceEndpoints[0]);
-      }
-
       jsPlumb.addEndpoint(refutation_id, {
         endpoint: "Dot",
         anchor: "TopLeft",

--- a/app/javascript/packs/agenda_board.js
+++ b/app/javascript/packs/agenda_board.js
@@ -18,9 +18,9 @@ jsPlumb.ready(function() {
       url: '/opinion_positions',
       method: 'GET',
       success: function(response) {
-        const argument_positions = response.argument_positions;
+        const opinion_positions = response.opinion_positions;
 
-        argument_positions.forEach(function(position) {
+        opinion_positions.forEach(function(position) {
           const argument_id_num = parseInt(argument_id.replace("argument", ""));
           if (position.argument_id === argument_id_num) {
             $(`#${argument_id}`).css({left: position.left + "px", top: position.top + "px"});
@@ -42,7 +42,7 @@ jsPlumb.ready(function() {
         url: '/opinion_positions',
         method: 'POST',
         data: {
-          argument_position: {
+          opinion_position: {
             argument_id: argument_id_num,
             refutation_id: null,
             left: position.left,
@@ -182,7 +182,7 @@ jsPlumb.ready(function() {
     }
   });
 
-  // 反論をドラッグ可能にし､リロード後も反論の位置が再現されるようにする + 反論の左上にソースエンドポイントを設置する
+  // 反論をドラッグ可能にし､リロード後も反論の位置が再現されるようにする + 反論のレイアウトを整える
   jsPlumb.registerConnectionTypes({
     "red-connection": {
       paintStyle: {stroke: "red", strokeWidth: 5},
@@ -194,142 +194,184 @@ jsPlumb.ready(function() {
   all_refutations.forEach( function( refutation ) {
     const refutation_id = refutation.getAttribute("id");
 
+    // 反論をドラッグ可能にし､ドラッグ終了後の反論の位置をopinion_positionsテーブルに保存する
     jsPlumb.draggable(`${refutation_id}`, {
       stop: function(event) {
-        savePositions();
+        savePosition(refutation_id, $(`#${refutation_id}`).position());
       }
     });
 
-    function savePositions() {
-      localStorage.setItem(`${refutation_id}_position`, JSON.stringify($(`#${refutation_id}`).position()));
-    }
+    // opinion_positionsテーブルのデータを使用して､ページ読み込み時に反論の位置を復元する + 反論のレイアウトを整える
+    $.ajax({
+      url: '/opinion_positions',
+      method: 'GET',
+      success: function(response) {
+        const opinion_positions = response.opinion_positions;
 
-    const refutation_position = JSON.parse(localStorage.getItem(`${refutation_id}_position`));
-    if (refutation_position) {
-      $(`#${refutation_id}`).css({left: refutation_position.left + "px", top: refutation_position.top + "px"});
-    }
+        opinion_positions.forEach(function(position) {
+          const refutation_id_num = parseInt(refutation_id.replace("refutation", ""));
+          if (position.refutation_id === refutation_id_num) {
+            $(`#${refutation_id}`).css({left: position.left + "px", top: position.top + "px"});
+          }
+        });
+        // 遅延させないとレイアウトが乱れる
+        setTimeout(arrangeRefutationLayout, 10);
+        setTimeout(setSourceEndpoint, 10);
+      },
+      error: function(xhr, status, error) {
+        console.error('Error retrieving refutation positions:', error);
+      }
+    });
 
-    // 反論の左上にソースエンドポイントを設置する
-    jsPlumb.addEndpoint(`${refutation_id}`, {
-      endpoint: "Dot",
-      anchor: "TopLeft",
-      isSource: true,
-      connectionType: "red-connection"
-    })
-  });
-
-  // 反論(サンプル)の表示がツリー型になるよう接続線を引く + 反論内にターゲットエンドポイントを設置する
-  const ref_conclusions = document.querySelectorAll(".ref_conclusion");
-  ref_conclusions.forEach( function( ref_conclusion ) {
-    const ref_conclusion_id = ref_conclusion.getAttribute("id");
-
-    jsPlumb.addEndpoint(`${ref_conclusion_id}`, {
-      endpoint: "Dot",
-      anchor: "RightMiddle",
-      isTarget: true,
-      connectionType: "red-connection"
-    })
-    jsPlumb.addEndpoint(`${ref_conclusion_id}`, {
-      endpoint: "Dot",
-      anchor: "LeftMiddle",
-      isTarget: true,
-      connectionType: "red-connection"
-    })
-
-    const ref_reasons_of_ref_conclusion = document.querySelectorAll(`.ref_reason_of_${ref_conclusion_id}`);
-    ref_reasons_of_ref_conclusion.forEach( function( ref_reason ) {
-      const ref_reason_id = ref_reason.getAttribute("id");
-
-      jsPlumb.connect({
-        source: `${ref_conclusion_id}`,
-        target: `endpoint_between_${ref_conclusion_id}_and_${ref_reason_id}`,
-        anchors: ["Bottom", "Top"],
-        connector: "Straight",
-        endpoint:"Blank",
-        overlays:[
-          ["Arrow", {width: 10, length: 10}]
-        ]
-      });
-
-      jsPlumb.addEndpoint(`endpoint_between_${ref_conclusion_id}_and_${ref_reason_id}`, {
+    // 反論の左上にソースエンドポイントを設置する関数
+    function setSourceEndpoint() {
+      jsPlumb.addEndpoint(`${refutation_id}`, {
         endpoint: "Dot",
-        anchor: "Center",
-        isTarget: true,
-        connectionType: "red-connection",
-      })
-
-      jsPlumb.connect({
-        source: `endpoint_between_${ref_conclusion_id}_and_${ref_reason_id}`,
-        target: `${ref_reason_id}`,
-        anchors: ["Bottom", "Top"],
-        connector: "Straight",
-        endpoint:"Blank",
-        overlays:[
-          ["Arrow", {width: 10, length: 10}]
-        ]
-      });
-
-      jsPlumb.addEndpoint(`${ref_reason_id}`, {
-        endpoint: "Dot",
-        anchor: "RightMiddle",
-        isTarget: true,
+        anchor: "TopLeft",
+        isSource: true,
         connectionType: "red-connection"
       })
-      jsPlumb.addEndpoint(`${ref_reason_id}`, {
-        endpoint: "Dot",
-        anchor: "LeftMiddle",
-        isTarget: true,
-        connectionType: "red-connection"
-      })
+    }
 
-      const ref_evidences_of_ref_reason = document.querySelectorAll(`.ref_evidence_of_${ref_reason_id}`);
+    // 反論のドラッグ終了後の位置をopinion_positionsテーブルに保存する関数
+    function savePosition(refutation_id, position) {
+      const refutation_id_num = parseInt(refutation_id.replace("refutation", ""));
 
-      ref_evidences_of_ref_reason.forEach( function( ref_evidence ) {
-        const ref_evidence_id = ref_evidence.getAttribute("id");
+      $.ajax({
+        url: '/opinion_positions',
+        method: 'POST',
+        data: {
+          opinion_position: {
+            argument_id: null,
+            refutation_id: refutation_id_num,
+            left: position.left,
+            top: position.top
+          }
+        },
+        success: function(response) {
+          console.log(response.message)
+        },
+        error: function(xhr, status, error) {
+          console.error('Error saving refutation position:', error);
+        }
+      });
+    }
 
-        jsPlumb.connect({
-          source: `${ref_reason_id}`,
-          target: `endpoint_between_${ref_reason_id}_and_${ref_evidence_id}`,
-          anchors: ["Bottom", "Top"],
-          connector: "Straight",
-          endpoint:"Blank",
-          overlays:[
-            ["Arrow", {width: 10, length: 10}]
-          ]
-        });
+    // 反論の表示がツリー型になるよう接続線を引く + 反論内にターゲットエンドポイントを設置する関数
+    function arrangeRefutationLayout() {
+      const ref_conclusions = document.querySelectorAll(".ref_conclusion");
+      ref_conclusions.forEach( function( ref_conclusion ) {
+        const ref_conclusion_id = ref_conclusion.getAttribute("id");
 
-        jsPlumb.addEndpoint(`endpoint_between_${ref_reason_id}_and_${ref_evidence_id}`, {
-          endpoint: "Dot",
-          anchor: "Center",
-          isTarget: true,
-          connectionType: "red-connection"
-        })
-
-        jsPlumb.connect({
-          source: `endpoint_between_${ref_reason_id}_and_${ref_evidence_id}`,
-          target: `${ref_evidence_id}`,
-          anchors: ["Bottom", "Top"],
-          connector: "Straight",
-          endpoint:"Blank",
-          overlays:[
-            ["Arrow", {width: 10, length: 10}]
-          ]
-        });
-
-        jsPlumb.addEndpoint(`${ref_evidence_id}`, {
+        jsPlumb.addEndpoint(`${ref_conclusion_id}`, {
           endpoint: "Dot",
           anchor: "RightMiddle",
           isTarget: true,
           connectionType: "red-connection"
         })
-        jsPlumb.addEndpoint(`${ref_evidence_id}`, {
+        jsPlumb.addEndpoint(`${ref_conclusion_id}`, {
           endpoint: "Dot",
           anchor: "LeftMiddle",
           isTarget: true,
           connectionType: "red-connection"
         })
+
+        const ref_reasons_of_ref_conclusion = document.querySelectorAll(`.ref_reason_of_${ref_conclusion_id}`);
+        ref_reasons_of_ref_conclusion.forEach( function( ref_reason ) {
+          const ref_reason_id = ref_reason.getAttribute("id");
+
+          jsPlumb.connect({
+            source: `${ref_conclusion_id}`,
+            target: `endpoint_between_${ref_conclusion_id}_and_${ref_reason_id}`,
+            anchors: ["Bottom", "Top"],
+            connector: "Straight",
+            endpoint:"Blank",
+            overlays:[
+              ["Arrow", {width: 10, length: 10}]
+            ]
+          });
+
+          jsPlumb.addEndpoint(`endpoint_between_${ref_conclusion_id}_and_${ref_reason_id}`, {
+            endpoint: "Dot",
+            anchor: "Center",
+            isTarget: true,
+            connectionType: "red-connection",
+          })
+
+          jsPlumb.connect({
+            source: `endpoint_between_${ref_conclusion_id}_and_${ref_reason_id}`,
+            target: `${ref_reason_id}`,
+            anchors: ["Bottom", "Top"],
+            connector: "Straight",
+            endpoint:"Blank",
+            overlays:[
+              ["Arrow", {width: 10, length: 10}]
+            ]
+          });
+
+          jsPlumb.addEndpoint(`${ref_reason_id}`, {
+            endpoint: "Dot",
+            anchor: "RightMiddle",
+            isTarget: true,
+            connectionType: "red-connection"
+          })
+          jsPlumb.addEndpoint(`${ref_reason_id}`, {
+            endpoint: "Dot",
+            anchor: "LeftMiddle",
+            isTarget: true,
+            connectionType: "red-connection"
+          })
+
+          const ref_evidences_of_ref_reason = document.querySelectorAll(`.ref_evidence_of_${ref_reason_id}`);
+
+          ref_evidences_of_ref_reason.forEach( function( ref_evidence ) {
+            const ref_evidence_id = ref_evidence.getAttribute("id");
+
+            jsPlumb.connect({
+              source: `${ref_reason_id}`,
+              target: `endpoint_between_${ref_reason_id}_and_${ref_evidence_id}`,
+              anchors: ["Bottom", "Top"],
+              connector: "Straight",
+              endpoint:"Blank",
+              overlays:[
+                ["Arrow", {width: 10, length: 10}]
+              ]
+            });
+
+            jsPlumb.addEndpoint(`endpoint_between_${ref_reason_id}_and_${ref_evidence_id}`, {
+              endpoint: "Dot",
+              anchor: "Center",
+              isTarget: true,
+              connectionType: "red-connection"
+            })
+
+            jsPlumb.connect({
+              source: `endpoint_between_${ref_reason_id}_and_${ref_evidence_id}`,
+              target: `${ref_evidence_id}`,
+              anchors: ["Bottom", "Top"],
+              connector: "Straight",
+              endpoint:"Blank",
+              overlays:[
+                ["Arrow", {width: 10, length: 10}]
+              ]
+            });
+
+            jsPlumb.addEndpoint(`${ref_evidence_id}`, {
+              endpoint: "Dot",
+              anchor: "RightMiddle",
+              isTarget: true,
+              connectionType: "red-connection"
+            })
+            jsPlumb.addEndpoint(`${ref_evidence_id}`, {
+              endpoint: "Dot",
+              anchor: "LeftMiddle",
+              isTarget: true,
+              connectionType: "red-connection"
+            })
+          });
+        });
       });
-    });
+    }
   });
 
   // 接続線が右クリックされたとき､｢削除ボタン｣を表示する

--- a/app/models/conclusion.rb
+++ b/app/models/conclusion.rb
@@ -6,6 +6,8 @@ class Conclusion < ApplicationRecord
 
   has_many :ref_conclusions
 
+  has_one :opinion_position, foreign_key: 'argument_id'
+
   validates :agenda_board_id, presence: true
   validates :conclusion_summary, presence: true
 end

--- a/app/models/conclusion.rb
+++ b/app/models/conclusion.rb
@@ -6,7 +6,7 @@ class Conclusion < ApplicationRecord
 
   has_many :ref_conclusions
 
-  has_one :opinion_position, foreign_key: 'argument_id'
+  has_one :opinion_position, foreign_key: 'argument_id', dependent: :destroy
 
   validates :agenda_board_id, presence: true
   validates :conclusion_summary, presence: true

--- a/app/models/opinion_connection.rb
+++ b/app/models/opinion_connection.rb
@@ -1,0 +1,2 @@
+class OpinionConnection < ApplicationRecord
+end

--- a/app/models/opinion_position.rb
+++ b/app/models/opinion_position.rb
@@ -1,3 +1,4 @@
 class OpinionPosition < ApplicationRecord
   belongs_to :argument, class_name: 'Conclusion', optional: true
+  belongs_to :refutation, class_name: 'RefConclusion', optional: true
 end

--- a/app/models/opinion_position.rb
+++ b/app/models/opinion_position.rb
@@ -1,0 +1,2 @@
+class OpinionPosition < ApplicationRecord
+end

--- a/app/models/opinion_position.rb
+++ b/app/models/opinion_position.rb
@@ -1,2 +1,3 @@
 class OpinionPosition < ApplicationRecord
+  belongs_to :argument, class_name: 'Conclusion', optional: true
 end

--- a/app/models/ref_conclusion.rb
+++ b/app/models/ref_conclusion.rb
@@ -9,7 +9,7 @@ class RefConclusion < ApplicationRecord
   belongs_to :parent_ref_conclusion, class_name: 'RefConclusion', optional: true
   has_many :child_ref_conclusions, class_name: 'RefConclusion', foreign_key: 'parent_ref_conclusion_id'
 
-  has_one :opinion_position, foreign_key: 'refutation_id'
+  has_one :opinion_position, foreign_key: 'refutation_id', dependent: :destroy
 
   validates :agenda_board_id, presence: true
   validates :ref_conclusion_summary, presence: true

--- a/app/models/ref_conclusion.rb
+++ b/app/models/ref_conclusion.rb
@@ -9,6 +9,8 @@ class RefConclusion < ApplicationRecord
   belongs_to :parent_ref_conclusion, class_name: 'RefConclusion', optional: true
   has_many :child_ref_conclusions, class_name: 'RefConclusion', foreign_key: 'parent_ref_conclusion_id'
 
+  has_one :opinion_position, foreign_key: 'refutation_id'
+
   validates :agenda_board_id, presence: true
   validates :ref_conclusion_summary, presence: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,5 @@ Rails.application.routes.draw do
     get 'sign_out', :to => 'users/sessions#destroy'
   end
 
-  resources :agenda_boards, :arguments, :refutations, :opinion_positions
+  resources :agenda_boards, :arguments, :refutations, :opinion_positions, :opinion_connections
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,5 @@ Rails.application.routes.draw do
     get 'sign_out', :to => 'users/sessions#destroy'
   end
 
-  resources :agenda_boards, :arguments, :refutations
+  resources :agenda_boards, :arguments, :refutations, :opinion_positions
 end

--- a/db/migrate/20230613151637_create_opinion_positions.rb
+++ b/db/migrate/20230613151637_create_opinion_positions.rb
@@ -8,7 +8,5 @@ class CreateOpinionPositions < ActiveRecord::Migration[6.0]
 
       t.timestamps
     end
-    add_index :opinion_positions, :argument_id, unique: true
-    add_index :opinion_positions, :refutation_id, unique: true
   end
 end

--- a/db/migrate/20230613151637_create_opinion_positions.rb
+++ b/db/migrate/20230613151637_create_opinion_positions.rb
@@ -1,0 +1,14 @@
+class CreateOpinionPositions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :opinion_positions do |t|
+      t.references :argument, null: true, foreign_key: { to_table: :conclusions }
+      t.references :refutation, null: true, foreign_key: { to_table: :ref_conclusions }
+      t.integer :left
+      t.integer :top
+
+      t.timestamps
+    end
+    add_index :opinion_positions, :argument_id, unique: true
+    add_index :opinion_positions, :refutation_id, unique: true
+  end
+end

--- a/db/migrate/20230620091239_create_opinion_connections.rb
+++ b/db/migrate/20230620091239_create_opinion_connections.rb
@@ -1,0 +1,10 @@
+class CreateOpinionConnections < ActiveRecord::Migration[6.0]
+  def change
+    create_table :opinion_connections do |t|
+      t.string :source_id
+      t.string :target_id
+      t.string :source_endpoint_id
+      t.string :target_endpoint_id
+    end
+  end
+end

--- a/db/migrate/20230621091029_update_opinion_connections.rb
+++ b/db/migrate/20230621091029_update_opinion_connections.rb
@@ -1,0 +1,8 @@
+class UpdateOpinionConnections < ActiveRecord::Migration[6.0]
+  def change
+    change_table :opinion_connections do |t|
+      t.remove :source_endpoint_id, :target_endpoint_id
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_20_091239) do
+ActiveRecord::Schema.define(version: 2023_06_21_091029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,8 +44,8 @@ ActiveRecord::Schema.define(version: 2023_06_20_091239) do
   create_table "opinion_connections", force: :cascade do |t|
     t.string "source_id"
     t.string "target_id"
-    t.string "source_endpoint_id"
-    t.string "target_endpoint_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "opinion_positions", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_13_151637) do
+ActiveRecord::Schema.define(version: 2023_06_20_091239) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,13 @@ ActiveRecord::Schema.define(version: 2023_06_13_151637) do
     t.text "evidence_detail"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "opinion_connections", force: :cascade do |t|
+    t.string "source_id"
+    t.string "target_id"
+    t.string "source_endpoint_id"
+    t.string "target_endpoint_id"
   end
 
   create_table "opinion_positions", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_25_133819) do
+ActiveRecord::Schema.define(version: 2023_06_13_151637) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,17 @@ ActiveRecord::Schema.define(version: 2023_05_25_133819) do
     t.text "evidence_detail"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "opinion_positions", force: :cascade do |t|
+    t.bigint "argument_id"
+    t.bigint "refutation_id"
+    t.integer "left"
+    t.integer "top"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["argument_id"], name: "index_opinion_positions_on_argument_id", unique: true
+    t.index ["refutation_id"], name: "index_opinion_positions_on_refutation_id", unique: true
   end
 
   create_table "reasons", force: :cascade do |t|
@@ -96,6 +107,8 @@ ActiveRecord::Schema.define(version: 2023_05_25_133819) do
   end
 
   add_foreign_key "conclusions", "users"
+  add_foreign_key "opinion_positions", "conclusions", column: "argument_id"
+  add_foreign_key "opinion_positions", "ref_conclusions", column: "refutation_id"
   add_foreign_key "ref_conclusions", "agenda_boards"
   add_foreign_key "ref_conclusions", "conclusions"
   add_foreign_key "ref_conclusions", "ref_conclusions", column: "parent_ref_conclusion_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -166,3 +166,16 @@ OpinionPosition.create!(
     }
   ]
 )
+
+OpinionConnection.create!(
+  [
+    {
+      source_id: 'refutation1',
+      target_id: 'reason0_of_conclusion1'
+    },
+    {
+      source_id: 'refutation2',
+      target_id: 'endpoint_between_ref_reason0_of_ref_conclusion1_and_ref_evidence0_of_ref_reason0_of_ref_conclusion1'
+    }
+  ]
+)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -146,3 +146,23 @@ RefEvidence.create!(
   ref_evidence_summary: '論理性の話であるため､必要なし',
   ref_evidence_detail: '特になし'
 )
+
+OpinionPosition.create!(
+  [
+    {
+      refutation_id: 1,
+      left: 1500,
+      top: 150
+    },
+    {
+      refutation_id: 2,
+      left: 2300,
+      top: 150
+    },
+    {
+      argument_id: 2,
+      left: 10,
+      top: 1000
+    }
+  ]
+)


### PR DESCRIPTION
## 関連するチケット､Issue､プルリクエストのリンク

* #19

## なぜこの変更をするのか

* 別ブラウザ間で､意見の位置情報や意見間の接続線情報が共有されるようにするため｡
  (詳細は #19 に記載)

## やったこと

1.  意見(主張や反論)の位置情報の保存場所をローカルストレージからopinion_positionsテーブルに移行
2. 意見間の接続線情報の保存場所をローカルストレージからopinion_connectionsテーブルに移行
3. 意見の位置情報や意見間の接続線情報のサンプルデータをseedファイルに追記

## やらないこと

* #21  や #22 
→ アプリが使用できなくなるほど大きな不具合や機能ではないため､全体的な実装が終わり次第対応する

## 変更内容 

以降の操作において､パソコンAを操作する時は､事前に以下2つの操作を行った｡
* **パソコンAのデフォルトブラウザである｢Google Chrome｣のローカルストレージ中のデータを削除**
1. Google Chromeを開き､右上のメニューアイコン（3つの縦の点）をクリック
2. ｢設定｣ をクリック
3. ｢プライバシーとセキュリティ｣をクリック
4. ｢閲覧履歴データの削除｣をクリック
5. ｢Cookieと他のサイトデータ｣のチェックボックスにチェックを入れ､｢データを削除｣をクリック

* **パソコンAで､アプリ(https://visual-discussion.herokuapp.com/)  のDBをリセットしてシードファイル読み込む**

`ターミナル`
`$ heroku pg:reset -a visual-discussion`

`$ heroku run rails db:migrate`

`$ heroku run rails db:seed`


また､パソコンBを操作する時は､事前に以下の操作を行った｡
* **パソコンBのデフォルトブラウザである｢Google Chrome｣のローカルストレージ中のデータを削除**

## before

### 1. パソコンAで､アプリ(https://visual-discussion.herokuapp.com/)   の議題ボード詳細ページを開き､意見の位置や意見間の接続線の状況を確認する｡


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/98ba6a13-54fb-4e0a-a21b-1ffe51d35535





→  意見の位置情報や意見間の接続線情報のデータが存在しないため､すべての意見が左上に重なっているのに加え､接続線が引かれていない｡

### 2. パソコンAの同様のページで､適当に意見を配置したり､意見間に接続線を引いたりする｡

https://github.com/tikuwabux/VisualDiscussion/assets/111355072/1c677dc6-b8d7-473a-90f3-eaa01f2ee26f



### 3. パソコンBでアプリ(https://visual-discussion.herokuapp.com/) を開き､同一の議題ボード詳細ページを開く｡


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/433dc916-3f8b-49d3-91ec-4ca7898763c8



→ 2の操作が反映されていないため､すべての意見が左上に重なっているのに加え､接続線が引かれていない｡


## after
### 1. パソコンAで､アプリ(https://visual-discussion.herokuapp.com/)   の議題ボード詳細ページを開き､意見の位置や意見間の接続線の状況を確認する｡

https://github.com/tikuwabux/VisualDiscussion/assets/111355072/a3b60793-724c-411a-b889-384de71f5112


→ seedファイル中のサンブルデータに基づいた位置に意見が配置されていたり､意見間の接続線が作成されている

### 2. パソコンAの同様のページで､意見間の配置や､意見間の接続線の接続先を変更したりする｡

https://github.com/tikuwabux/VisualDiscussion/assets/111355072/5b8c1242-6fd8-405f-92b0-9acb67a06d2c



### 3. パソコンBでアプリ(https://visual-discussion.herokuapp.com/) を開き､同一の議題ボード詳細ページを開く｡


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/41735946-008f-4f8e-aa17-37cd92f604ad



→ 2の操作が反映されており､パソコンA-Bのブラウザ間において､意見の位置情報や意見間の接続線情報を共有することに成功している｡


## できるようになること（ユーザ目線)
* アプリのサンプルデータが入っている議題ボード詳細ページで､理想的な意見の位置や､意見間の接続線の引き方を確認すること

* 別ブラウザ間で意見の位置情報や意見間の接続線情報を共有すること

## できなくなること（ユーザ目線）

*  無し
## 動作確認

### 本番環境下
以下の点を､手動で確認した｡
1. - [x] seedファイル中のサンブルデータに基づいた位置に意見が配置されていたり､意見間の接続線が作成されていること
2. - [x] パソコンA-Bのブラウザ間において､意見の位置情報や意見間の接続線情報を共有できること

## その他

* 無し
