### PR TITLE
ヘッダー中に､議題ボード検索フォームを設置する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,3 +65,4 @@ gem 'pry-rails'
 gem 'rails-i18n'
 gem 'cocoon'
 gem "jquery-rails"
+gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,10 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.1.1)
     rake (13.0.6)
+    ransack (3.1.0)
+      activerecord (>= 6.0.4)
+      activesupport (>= 6.0.4)
+      i18n
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -327,6 +331,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.6)
   rails-i18n
+  ransack
   rspec-rails
   rubocop-airbnb
   sass-rails (>= 6)

--- a/app/controllers/agenda_boards_controller.rb
+++ b/app/controllers/agenda_boards_controller.rb
@@ -38,7 +38,7 @@ class AgendaBoardsController < ApplicationController
   def index_searched_by_agenda
     @input_content = params[:q][:agenda_cont]
     keywords = @input_content.split(/[\p{blank}\s]+/)
-    grouping_array = keywords.reduce([]){ |array, word| array << { agenda_cont: word } }
+    grouping_array = keywords.reduce([]) { |array, word| array << { agenda_cont: word } }
     search = AgendaBoard.ransack({ combinator: 'and', groupings: grouping_array })
     @search_result_agenda_boards = search.result.order(created_at: :desc)
   end

--- a/app/controllers/agenda_boards_controller.rb
+++ b/app/controllers/agenda_boards_controller.rb
@@ -29,6 +29,12 @@ class AgendaBoardsController < ApplicationController
     @agenda_boards = AgendaBoard.where(id: agenda_board_ids).order(created_at: :desc)
   end
 
+  def index_searched_by_category
+    @search_category = params[:q][:category_cont]
+    search = AgendaBoard.ransack(params[:q])
+    @search_result_agenda_boards = search.result.order(created_at: :desc)
+  end
+
   def edit
     @agenda_board = AgendaBoard.find(params[:id])
   end

--- a/app/controllers/agenda_boards_controller.rb
+++ b/app/controllers/agenda_boards_controller.rb
@@ -35,6 +35,14 @@ class AgendaBoardsController < ApplicationController
     @search_result_agenda_boards = search.result.order(created_at: :desc)
   end
 
+  def index_searched_by_agenda
+    @input_content = params[:q][:agenda_cont]
+    keywords = @input_content.split(/[\p{blank}\s]+/)
+    grouping_array = keywords.reduce([]){ |array, word| array << { agenda_cont: word } }
+    search = AgendaBoard.ransack({ combinator: 'and', groupings: grouping_array })
+    @search_result_agenda_boards = search.result.order(created_at: :desc)
+  end
+
   def edit
     @agenda_board = AgendaBoard.find(params[:id])
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,7 @@
 class ApplicationController < ActionController::Base
+  before_action :prepare_agenda_board_search_form
+
+  def prepare_agenda_board_search_form
+    @search = AgendaBoard.ransack(params[:q])
+  end
 end

--- a/app/views/agenda_boards/index_searched_by_agenda.erb
+++ b/app/views/agenda_boards/index_searched_by_agenda.erb
@@ -1,0 +1,39 @@
+<h3>｢<%= @input_content %>｣を議題名に含む議題ボード一覧</h3>
+<table>
+  <thead>
+    <tr>
+      <th>議題</th>
+      <th>カテゴリ</th>
+      <th>作成日</th>
+      <th>編集</th>
+      <th>削除</th>
+      <th>意見数</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @search_result_agenda_boards.each do |agenda_board| %>
+    <tr id="agenda_board<%= agenda_board.id %>">
+      <td><%= link_to agenda_board.agenda, agenda_board_path(agenda_board.id) %></td>
+      <td><%= agenda_board.category %></td>
+      <td><%= agenda_board.created_at %></td>
+      <td>
+        <% if current_user.id = agenda_board.user_id && agenda_board.conclusions == [] && agenda_board.ref_conclusions == [] %>
+          <%= link_to "編集", edit_agenda_board_path(agenda_board.id) %>
+        <% else %>
+          編集不可
+        <% end %>
+      </td>
+      <td>
+        <% if current_user.id = agenda_board.user_id && agenda_board.conclusions == [] && agenda_board.ref_conclusions == [] %>
+          <%= link_to "削除", agenda_board_path(agenda_board.id), method: :delete %>
+        <% else %>
+          削除不可
+        <% end %>
+      </td>
+      <td>
+        <%= agenda_board.conclusions.count + agenda_board.ref_conclusions.count %>
+      </td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/agenda_boards/index_searched_by_category.erb
+++ b/app/views/agenda_boards/index_searched_by_category.erb
@@ -1,4 +1,4 @@
-<h3>｢<%= @search_category %>｣の議題ボード一覧</h3>
+<h3>｢<%= @search_category %>｣のカテゴリをもつ議題ボード一覧</h3>
 <table>
   <thead>
     <tr>

--- a/app/views/agenda_boards/index_searched_by_category.erb
+++ b/app/views/agenda_boards/index_searched_by_category.erb
@@ -1,0 +1,39 @@
+<h3>｢<%= @search_category %>｣の議題ボード一覧</h3>
+<table>
+  <thead>
+    <tr>
+      <th>議題</th>
+      <th>カテゴリ</th>
+      <th>作成日</th>
+      <th>編集</th>
+      <th>削除</th>
+      <th>意見数</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @search_result_agenda_boards.each do |agenda_board| %>
+    <tr id="agenda_board<%= agenda_board.id %>">
+      <td><%= link_to agenda_board.agenda, agenda_board_path(agenda_board.id) %></td>
+      <td><%= agenda_board.category %></td>
+      <td><%= agenda_board.created_at %></td>
+      <td>
+        <% if current_user.id = agenda_board.user_id && agenda_board.conclusions == [] && agenda_board.ref_conclusions == [] %>
+          <%= link_to "編集", edit_agenda_board_path(agenda_board.id) %>
+        <% else %>
+          編集不可
+        <% end %>
+      </td>
+      <td>
+        <% if current_user.id = agenda_board.user_id && agenda_board.conclusions == [] && agenda_board.ref_conclusions == [] %>
+          <%= link_to "削除", agenda_board_path(agenda_board.id), method: :delete %>
+        <% else %>
+          削除不可
+        <% end %>
+      </td>
+      <td>
+        <%= agenda_board.conclusions.count + agenda_board.ref_conclusions.count %>
+      </td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,12 @@
           <%= link_to '新規議題ボード作成ページへ', new_agenda_board_path %>
           <%= link_to "作成した議題ボード一覧", current_user_created_agenda_boards_path %>
           <%= link_to '意見を投稿した議題ボード一覧', current_user_posted_opinion_agenda_boards_path %>
+          <%= search_form_for @search, url: category_search_agenda_boards_path do |form| %>
+            <%= form.label :category_cont, 'カテゴリ名' %>
+            <%= form.select :category_cont, options_for_select(["ビジネス", "哲学", "歴史", "社会科学", "自然科学", "技術・工学", "産業", "芸術・美術", "言語", "文学", "その他"]) %>
+            <br>
+            <%= form.submit %>
+          <% end %>
         <% else %>
           <%= link_to 'サインアップ', sign_up_path %>
           <%= link_to 'ログイン', sign_in_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,7 @@
             <%= form.label :agenda_cont, '議題名(複数単語可)' %>
             <%= form.search_field :agenda_cont %>
             <br>
-            <%= form.submit %>
+            <%= form.submit '議題名で検索' %>
           <% end %>
         <% else %>
           <%= link_to 'サインアップ', sign_up_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,12 @@
             <br>
             <%= form.submit %>
           <% end %>
+          <%= search_form_for @search, url: agenda_search_agenda_boards_path do |form| %>
+            <%= form.label :agenda_cont, '議題名(複数単語可)' %>
+            <%= form.search_field :agenda_cont %>
+            <br>
+            <%= form.submit %>
+          <% end %>
         <% else %>
           <%= link_to 'サインアップ', sign_up_path %>
           <%= link_to 'ログイン', sign_in_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,9 +19,9 @@
           <%= link_to '意見を投稿した議題ボード一覧', current_user_posted_opinion_agenda_boards_path %>
           <%= search_form_for @search, url: category_search_agenda_boards_path do |form| %>
             <%= form.label :category_cont, 'カテゴリ名' %>
-            <%= form.select :category_cont, options_for_select(["ビジネス", "哲学", "歴史", "社会科学", "自然科学", "技術・工学", "産業", "芸術・美術", "言語", "文学", "その他"]) %>
+            <%= form.select :category_cont, options_for_select(["ビジネス", "哲学", "歴史", "社会科学", "自然科学", "技術・工学", "産業", "芸術・美術", "言語", "文学", "その他"]), {}, { id: "agenda_board_search_category" } %>
             <br>
-            <%= form.submit %>
+            <%= form.submit 'カテゴリ名で検索'%>
           <% end %>
           <%= search_form_for @search, url: agenda_search_agenda_boards_path do |form| %>
             <%= form.label :agenda_cont, '議題名(複数単語可)' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
     collection do
       get 'index_created_by_current_user', as: 'current_user_created'
       get 'index_with_opinion_posted_by_current_user', as: 'current_user_posted_opinion'
+      get 'index_searched_by_category', as: 'category_search'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
       get 'index_created_by_current_user', as: 'current_user_created'
       get 'index_with_opinion_posted_by_current_user', as: 'current_user_posted_opinion'
       get 'index_searched_by_category', as: 'category_search'
+      get 'index_searched_by_agenda', as: 'agenda_search'
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,9 +16,18 @@ User.create!(
 )
 
 AgendaBoard.create!(
-  user_id: 1,
-  agenda: '早起きは健康によいのか',
-  category: '自然科学'
+  [
+    {
+      user_id: 1,
+      agenda: '早起きは健康によいのか',
+      category: '自然科学'
+    },
+    {
+      user_id: 1,
+      agenda: '何時に起きるのが一番健康的なのか',
+      category: '自然科学'
+    }
+  ]
 )
 
 # annieの主張1(brianからの反論有り)

--- a/spec/system/agenda_boards_spec.rb
+++ b/spec/system/agenda_boards_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "AgendaBoards", type: :system do
 
   let(:about_early_bird) { create(:agenda_board, user_id: annie.id, agenda: "早起きは健康によいのか?", category: "自然科学") }
   let!(:about_chatbot) { create(:agenda_board, user_id: annie.id, agenda: "チャットボットは教育に悪影響を与えるのか?", category: "社会科学") }
+  let!(:about_ideal_waking_time) { create(:agenda_board, user_id: annie.id, agenda: "何時に起きるのが一番健康的なのか?", category: "自然科学") }
 
   let(:bad_for_health) do
     create(:conclusion, agenda_board_id: about_early_bird.id, user_id: annie.id, conclusion_summary: "健康に悪い")
@@ -169,6 +170,65 @@ RSpec.describe "AgendaBoards", type: :system do
     scenario "議題名をクリックすると､その議題ボードの詳細ページに遷移すること" do
       click_on about_early_bird.agenda
       expect(page).to have_current_path agenda_board_path(about_early_bird.id)
+    end
+  end
+
+  describe "選択したカテゴリを有する議題ボード一覧ページにアクセス後" do
+    before do
+      select "自然科学", from: 'agenda_board_search_category'
+      click_on 'カテゴリ名で検索'
+      @agenda_boards = AgendaBoard.where(category: '自然科学')
+    end
+
+    scenario "議題ボードの議題名の一覧を動的に確認できる" do
+      @agenda_boards.all? { |agenda_board| expect(page).to have_content agenda_board.agenda }
+    end
+
+    scenario "議題ボードのカテゴリ名の一覧を動的に確認できる" do
+      @agenda_boards.all? { |agenda_board| expect(page).to have_content agenda_board.category }
+    end
+
+    scenario "議題ボードの作成日の一覧を動的に確認できる" do
+      @agenda_boards.all? { |agenda_board| expect(page).to have_content agenda_board.created_at }
+    end
+
+    scenario "議題ボードに投稿されている意見数の一覧を動的に確認できる" do
+      @agenda_boards.all? do |agenda_board|
+        expect(page).to have_content agenda_board.conclusions.count + agenda_board.ref_conclusions.count
+      end
+    end
+
+    scenario "議題名をクリックすると､その議題ボードの詳細ページに遷移すること" do
+      click_on about_early_bird.agenda
+      expect(page).to have_current_path agenda_board_path(about_early_bird.id)
+    end
+
+    context "議題ボードの作成者が現在ログイン中のユーザーであることに加え､その議題ボード中で意見が1つも作成されていないとき" do
+      scenario "｢編集｣リンクの表示を確認できること" do
+        within "#agenda_board#{about_ideal_waking_time.id}" do
+          expect(page).to have_link "編集"
+        end
+      end
+
+      scenario "｢編集｣リンクをクリックすると､議題ボード編集ページに遷移すること" do
+        within "#agenda_board#{about_ideal_waking_time.id}" do
+          click_on "編集"
+          expect(page).to have_current_path edit_agenda_board_path(about_ideal_waking_time.id)
+        end
+      end
+
+      scenario "｢削除｣リンクの表示を確認できること" do
+        within "#agenda_board#{about_ideal_waking_time.id}" do
+          expect(page).to have_link "削除"
+        end
+      end
+
+      scenario "｢削除｣リンクをクリックすると､議題ボードが削除されること" do
+        within "#agenda_board#{about_ideal_waking_time.id}" do
+          click_on "削除"
+        end
+        expect(page).to have_content "議題ボードの削除に成功しました"
+      end
     end
   end
 

--- a/spec/system/agenda_boards_spec.rb
+++ b/spec/system/agenda_boards_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe "AgendaBoards", type: :system do
   let(:brian) { create(:user, name: "brian") }
 
   let(:about_early_bird) { create(:agenda_board, user_id: annie.id, agenda: "早起きは健康によいのか?", category: "自然科学") }
-  let!(:about_chatbot) { create(:agenda_board, user_id: annie.id, agenda: "チャットボットは教育に悪影響を与えるのか?", category: "社会科学") }
   let!(:about_ideal_waking_time) { create(:agenda_board, user_id: annie.id, agenda: "何時に起きるのが一番健康的なのか?", category: "自然科学") }
 
   let(:bad_for_health) do
@@ -115,26 +114,26 @@ RSpec.describe "AgendaBoards", type: :system do
 
     context "議題ボードの作成者が現在ログイン中のユーザーであることに加え､その議題ボード中で意見が1つも作成されていないとき" do
       scenario "｢編集｣リンクの表示を確認できること" do
-        within "#agenda_board#{about_chatbot.id}" do
+        within "#agenda_board#{about_ideal_waking_time.id}" do
           expect(page).to have_link "編集"
         end
       end
 
       scenario "｢編集｣リンクをクリックすると､議題ボード編集ページに遷移すること" do
-        within "#agenda_board#{about_chatbot.id}" do
+        within "#agenda_board#{about_ideal_waking_time.id}" do
           click_on "編集"
-          expect(page).to have_current_path edit_agenda_board_path(about_chatbot.id)
+          expect(page).to have_current_path edit_agenda_board_path(about_ideal_waking_time.id)
         end
       end
 
       scenario "｢削除｣リンクの表示を確認できること" do
-        within "#agenda_board#{about_chatbot.id}" do
+        within "#agenda_board#{about_ideal_waking_time.id}" do
           expect(page).to have_link "削除"
         end
       end
 
       scenario "｢削除｣リンクをクリックすると､議題ボードが削除されること" do
-        within "#agenda_board#{about_chatbot.id}" do
+        within "#agenda_board#{about_ideal_waking_time.id}" do
           click_on "削除"
         end
         expect(page).to have_content "議題ボードの削除に成功しました"
@@ -417,10 +416,10 @@ RSpec.describe "AgendaBoards", type: :system do
   describe "議題ボード編集ページアクセス後､必要事項を入力して､｢編集する｣ボタンを押すと" do
     before do
       click_on "作成した議題ボード一覧"
-      within "#agenda_board#{about_chatbot.id}" do
+      within "#agenda_board#{about_ideal_waking_time.id}" do
         click_on "編集"
       end
-      fill_in "議題", with: "チャットボットは今後のビジネスにどのような影響を与えるか?"
+      fill_in "議題", with: "8時出社の会社員の場合､理想的な起床時間は何時か?"
       select "ビジネス", from: "agenda_board_category"
       click_button "編集する"
     end

--- a/spec/system/agenda_boards_spec.rb
+++ b/spec/system/agenda_boards_spec.rb
@@ -232,6 +232,65 @@ RSpec.describe "AgendaBoards", type: :system do
     end
   end
 
+  describe "｢xxx(入力された文字)｣を議題名に含む議題ボード一覧ページにアクセス後" do
+    before do
+      fill_in '議題名(複数単語可)', with: '起き 健康'
+      click_on '議題名で検索'
+      @agenda_boards = AgendaBoard.where("agenda LIKE ? AND agenda LIKE ?", "%起き%", "%健康%")
+    end
+
+    scenario "議題ボードの議題名の一覧を動的に確認できる" do
+      @agenda_boards.all? { |agenda_board| expect(page).to have_content agenda_board.agenda }
+    end
+
+    scenario "議題ボードのカテゴリ名の一覧を動的に確認できる" do
+      @agenda_boards.all? { |agenda_board| expect(page).to have_content agenda_board.category }
+    end
+
+    scenario "議題ボードの作成日の一覧を動的に確認できる" do
+      @agenda_boards.all? { |agenda_board| expect(page).to have_content agenda_board.created_at }
+    end
+
+    scenario "議題ボードに投稿されている意見数の一覧を動的に確認できる" do
+      @agenda_boards.all? do |agenda_board|
+        expect(page).to have_content agenda_board.conclusions.count + agenda_board.ref_conclusions.count
+      end
+    end
+
+    scenario "議題名をクリックすると､その議題ボードの詳細ページに遷移すること" do
+      click_on about_early_bird.agenda
+      expect(page).to have_current_path agenda_board_path(about_early_bird.id)
+    end
+
+    context "議題ボードの作成者が現在ログイン中のユーザーであることに加え､その議題ボード中で意見が1つも作成されていないとき" do
+      scenario "｢編集｣リンクの表示を確認できること" do
+        within "#agenda_board#{about_ideal_waking_time.id}" do
+          expect(page).to have_link "編集"
+        end
+      end
+
+      scenario "｢編集｣リンクをクリックすると､議題ボード編集ページに遷移すること" do
+        within "#agenda_board#{about_ideal_waking_time.id}" do
+          click_on "編集"
+          expect(page).to have_current_path edit_agenda_board_path(about_ideal_waking_time.id)
+        end
+      end
+
+      scenario "｢削除｣リンクの表示を確認できること" do
+        within "#agenda_board#{about_ideal_waking_time.id}" do
+          expect(page).to have_link "削除"
+        end
+      end
+
+      scenario "｢削除｣リンクをクリックすると､議題ボードが削除されること" do
+        within "#agenda_board#{about_ideal_waking_time.id}" do
+          click_on "削除"
+        end
+        expect(page).to have_content "議題ボードの削除に成功しました"
+      end
+    end
+  end
+
   describe "議題ボード詳細ページアクセス後" do
     before do
       click_on "作成した議題ボード一覧"

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -67,6 +67,13 @@ RSpec.describe "Home", type: :system do
         click_on "意見を投稿した議題ボード一覧"
         expect(page).to have_current_path current_user_posted_opinion_agenda_boards_path
       end
+
+      scenario "｢議題ボード検索フォーム(カテゴリ選択式)｣でカテゴリを選択して､検索ボタンを押すと､選択したカテゴリを有する議題ボード一覧ページに遷移すること" do
+        select "自然科学", from: 'agenda_board_search_category'
+        click_on 'カテゴリ名で検索'
+        expect(page).to have_current_path category_search_agenda_boards_path, ignore_query: true
+        expect(page).to have_content '｢自然科学｣のカテゴリをもつ議題ボード一覧'
+      end
     end
   end
 end

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -74,6 +74,13 @@ RSpec.describe "Home", type: :system do
         expect(page).to have_current_path category_search_agenda_boards_path, ignore_query: true
         expect(page).to have_content '｢自然科学｣のカテゴリをもつ議題ボード一覧'
       end
+
+      scenario "｢議題ボード検索フォーム(議題名入力式)｣で議題名を入力して､検索ボタンを押すと､入力した議題名を含む議題ボード一覧ページに遷移すること" do
+        fill_in '議題名(複数単語可)', with: '起き 健康'
+        click_on '議題名で検索'
+        expect(page).to have_current_path agenda_search_agenda_boards_path, ignore_query: true
+        expect(page).to have_content '｢起き 健康｣を議題名に含む議題ボード一覧'
+      end
     end
   end
 end


### PR DESCRIPTION
## 関連するチケット､Issue､プルリクエストのリンク

* #26

## なぜこの変更をするのか

* カテゴリ名や議題名での議題ボード検索ができないと不便で使いづらいから

## やったこと

1. 議題ボード検索フォーム(カテゴリ選択式)をヘッダー内に設置
2. 議題ボード検索フォーム(議題名入力式)をヘッダー内に設置

## やらないこと

* 無し

## 変更内容

### before
![before](https://github.com/tikuwabux/VisualDiscussion/assets/111355072/34a64cc4-2409-4945-ab08-486f8c2278ba)

### after

https://github.com/tikuwabux/VisualDiscussion/assets/111355072/876261a1-bce7-4f51-b68d-f84a526bccd5



## できるようになること（ユーザ目線）
1. 選択したカテゴリ毎の議題ボードの一覧を閲覧すること
2. 入力した文字を議題名に含む議題ボードの一覧を閲覧すること

## できなくなること（ユーザ目線）

* 無し

## 動作確認

### 開発環境下

システムスペックを実装することで､追加したUIをテストした結果､すべてのテストをパスした｡
![スクリーンショット 2023-07-14 21 54 47](https://github.com/tikuwabux/VisualDiscussion/assets/111355072/c3ff6acc-8989-4884-9d40-6ac1960a1329)

![スクリーンショット 2023-07-14 21 57 57](https://github.com/tikuwabux/VisualDiscussion/assets/111355072/c348e675-bb71-42a6-979d-bee826a252fb)


## その他

* 検索フォームの実装は主に以下の｢ルーム検索フォーム1,2｣を参考にした
https://github.com/tikuwabux/PotepanShare/blob/develop/app/views/layouts/application.html.erb

* システムスペックの実装は以下を参考にした
https://www.sejuku.net/blog/71189
