### PR TITLE
Access restrictions

### DIFF
--- a/app/controllers/agenda_boards_controller.rb
+++ b/app/controllers/agenda_boards_controller.rb
@@ -1,4 +1,6 @@
 class AgendaBoardsController < ApplicationController
+  before_action :authenticate_user
+
   def new
     @agenda_board = AgendaBoard.new
   end

--- a/app/controllers/agenda_boards_controller.rb
+++ b/app/controllers/agenda_boards_controller.rb
@@ -1,5 +1,6 @@
 class AgendaBoardsController < ApplicationController
   before_action :authenticate_user
+  before_action :check_user_has_authorization, { only: [:edit, :update, :destroy] }
 
   def new
     @agenda_board = AgendaBoard.new
@@ -71,5 +72,14 @@ class AgendaBoardsController < ApplicationController
 
   def agenda_board_params
     params.require(:agenda_board).permit(:user_id, :agenda, :category)
+  end
+
+  def check_user_has_authorization
+    agenda_board = AgendaBoard.find(params[:id])
+
+    if current_user.id != agenda_board.user_id
+      flash[:alert] = "編集/削除する権限があるのは､あなた自身が作成した議題ボードのみです"
+      redirect_to current_user_created_agenda_boards_path
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,11 @@ class ApplicationController < ActionController::Base
   def prepare_agenda_board_search_form
     @search = AgendaBoard.ransack(params[:q])
   end
+
+  def authenticate_user
+    if current_user == nil
+      flash[:alert] = "ログインもしくはサインアップが必要です"
+      redirect_to sign_in_path
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   end
 
   def authenticate_user
-    if current_user == nil
+    if current_user.nil?
       flash[:alert] = "ログインもしくはサインアップが必要です"
       redirect_to sign_in_path
     end

--- a/app/controllers/arguments_controller.rb
+++ b/app/controllers/arguments_controller.rb
@@ -1,4 +1,6 @@
 class ArgumentsController < ApplicationController
+  before_action :authenticate_user
+  
   def new
     @agenda_board_id = params[:agenda_board_id]
     @agenda_board_agenda = params[:agenda_board_agenda]

--- a/app/controllers/arguments_controller.rb
+++ b/app/controllers/arguments_controller.rb
@@ -65,7 +65,7 @@ class ArgumentsController < ApplicationController
 
     if current_user.id != argument.user_id
       flash[:alert] = "編集/削除する権限があるのは､あなた自身が作成した主張のみです"
-      redirect_to  agenda_board_path(argument.agenda_board_id)
+      redirect_to agenda_board_path(argument.agenda_board_id)
     end
   end
 end

--- a/app/controllers/arguments_controller.rb
+++ b/app/controllers/arguments_controller.rb
@@ -1,6 +1,7 @@
 class ArgumentsController < ApplicationController
   before_action :authenticate_user
-  
+  before_action :check_user_has_authorization, { only: [:edit, :update, :destroy] }
+
   def new
     @agenda_board_id = params[:agenda_board_id]
     @agenda_board_agenda = params[:agenda_board_agenda]
@@ -57,5 +58,14 @@ class ArgumentsController < ApplicationController
         :id, :reason_summary, :reason_detail, :_destroy,
         evidences_attributes: [:id, :evidence_summary, :evidence_detail, :_destroy],
       ])
+  end
+
+  def check_user_has_authorization
+    argument = Conclusion.find(params[:id])
+
+    if current_user.id != argument.user_id
+      flash[:alert] = "編集/削除する権限があるのは､あなた自身が作成した主張のみです"
+      redirect_to  agenda_board_path(argument.agenda_board_id)
+    end
   end
 end

--- a/app/controllers/refutations_controller.rb
+++ b/app/controllers/refutations_controller.rb
@@ -1,4 +1,6 @@
 class RefutationsController < ApplicationController
+  before_action :authenticate_user
+  
   def new
     @agenda_board_id = params[:agenda_board_id]
     @agenda_board_agenda = params[:agenda_board_agenda]

--- a/app/controllers/refutations_controller.rb
+++ b/app/controllers/refutations_controller.rb
@@ -1,6 +1,7 @@
 class RefutationsController < ApplicationController
   before_action :authenticate_user
-  
+  before_action :check_user_has_authorization, { only: [:edit, :update, :destroy] }
+
   def new
     @agenda_board_id = params[:agenda_board_id]
     @agenda_board_agenda = params[:agenda_board_agenda]
@@ -82,6 +83,15 @@ class RefutationsController < ApplicationController
       @rebuttal_target_conclusion = Conclusion.find(refutation_params[:conclusion_id])
     else
       @rebuttal_target_ref_conclusion = RefConclusion.find(refutation_params[:parent_ref_conclusion_id])
+    end
+  end
+
+  def check_user_has_authorization
+    refutation = RefConclusion.find(params[:id])
+
+    if current_user.id != refutation.user_id
+      flash[:alert] = "編集/削除する権限があるのは､あなた自身が作成した反論のみです"
+      redirect_to  agenda_board_path(refutation.agenda_board_id)
     end
   end
 end

--- a/app/controllers/refutations_controller.rb
+++ b/app/controllers/refutations_controller.rb
@@ -91,7 +91,7 @@ class RefutationsController < ApplicationController
 
     if current_user.id != refutation.user_id
       flash[:alert] = "編集/削除する権限があるのは､あなた自身が作成した反論のみです"
-      redirect_to  agenda_board_path(refutation.agenda_board_id)
+      redirect_to agenda_board_path(refutation.agenda_board_id)
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,0 @@
-module ApplicationHelper
-end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,2 +1,0 @@
-module HomeHelper
-end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,4 +67,6 @@ RSpec.configure do |config|
   config.include AgendaBoardsHelper
 
   Webdrivers::Chromedriver.required_version = '114.0.5735.90'
+
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/spec/requests/agenda_boards_spec.rb
+++ b/spec/requests/agenda_boards_spec.rb
@@ -14,8 +14,23 @@ RSpec.shared_examples("未ログインユーザーに対するアクセス制限
   end
 end
 
+RSpec.shared_examples("議題ボードの編集/削除に関するアクセス制限のテスト") do
+  it "302リダイレクトを返すこと" do
+    expect(response).to have_http_status(302)
+  end
+
+  it "ログインユーザーが作成した議題ボード一覧ページにリダイレクトされること" do
+    expect(response).to redirect_to(current_user_created_agenda_boards_path)
+  end
+
+  it "設定したフラッシュメッセージがセットされていること" do
+    expect(flash[:alert]).to eq("編集/削除する権限があるのは､あなた自身が作成した議題ボードのみです")
+  end
+end
+
 RSpec.describe "AgendaBoards", type: :request do
   let(:annie) { create(:user, name: "annie") }
+  let(:brian) { create(:user, name: "brian") }
   let!(:about_early_bird) { create(:agenda_board, user_id: annie.id, agenda: "早起きは健康によいのか?", category: "自然科学") }
 
   context "未ログイン時" do
@@ -67,6 +82,27 @@ RSpec.describe "AgendaBoards", type: :request do
     describe "DELETE /agenda_boards/:id" do
       before { delete agenda_board_path(about_early_bird.id) }
       include_examples("未ログインユーザーに対するアクセス制限のテスト")
+    end
+  end
+
+  context "既ログイン時" do
+    before { sign_in(brian) }
+
+    describe "以下の権限のない議題ボードの編集/削除に関するリクエストを行った時" do
+      describe "GET /agenda_boards/:id/edit" do
+        before { get edit_agenda_board_path(about_early_bird.id) }
+        include_examples("議題ボードの編集/削除に関するアクセス制限のテスト")
+      end
+
+      describe "PATCH /agenda_boards/:id" do
+        before { patch agenda_board_path(about_early_bird.id) }
+        include_examples("議題ボードの編集/削除に関するアクセス制限のテスト")
+      end
+
+      describe "DELETE /agenda_boards/:id" do
+        before { delete agenda_board_path(about_early_bird.id) }
+        include_examples("議題ボードの編集/削除に関するアクセス制限のテスト")
+      end
     end
   end
 end

--- a/spec/requests/agenda_boards_spec.rb
+++ b/spec/requests/agenda_boards_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.shared_examples("未ログイン時ユーザーに対するアクセス制限のテスト") do
+RSpec.shared_examples("未ログインユーザーに対するアクセス制限のテスト") do
   it "302リダイレクトを返すこと" do
     expect(response).to have_http_status(302)
   end
@@ -21,52 +21,52 @@ RSpec.describe "AgendaBoards", type: :request do
   context "未ログイン時" do
     describe "GET /agenda_boards/new" do
       before { get new_agenda_board_path }
-      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+      include_examples("未ログインユーザーに対するアクセス制限のテスト")
     end
 
     describe "POST /agenda_boards" do
       before { post agenda_boards_path }
-      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+      include_examples("未ログインユーザーに対するアクセス制限のテスト")
     end
 
     describe "GET /agenda_boards/:id" do
       before { get agenda_board_path(about_early_bird.id) }
-      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+      include_examples("未ログインユーザーに対するアクセス制限のテスト")
     end
 
     describe "GET /agenda_boards/index_created_by_current_user" do
       before { get current_user_created_agenda_boards_path }
-      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+      include_examples("未ログインユーザーに対するアクセス制限のテスト")
     end
 
     describe "GET /agenda_boards/index_with_opinion_posted_by_current_user" do
       before { get current_user_posted_opinion_agenda_boards_path }
-      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+      include_examples("未ログインユーザーに対するアクセス制限のテスト")
     end
 
     describe "GET /agenda_boards/index_searched_by_category" do
       before { get category_search_agenda_boards_path }
-      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+      include_examples("未ログインユーザーに対するアクセス制限のテスト")
     end
 
     describe "GET /agenda_boards/index_searched_by_agenda" do
       before { get agenda_search_agenda_boards_path }
-      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+      include_examples("未ログインユーザーに対するアクセス制限のテスト")
     end
 
-    describe "GET /agenda_boards/:id" do
+    describe "GET /agenda_boards/:id/edit" do
       before { get edit_agenda_board_path(about_early_bird.id) }
-      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+      include_examples("未ログインユーザーに対するアクセス制限のテスト")
     end
 
     describe "PATCH /agenda_boards/:id" do
       before { patch agenda_board_path(about_early_bird.id) }
-      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+      include_examples("未ログインユーザーに対するアクセス制限のテスト")
     end
 
     describe "DELETE /agenda_boards/:id" do
       before { delete agenda_board_path(about_early_bird.id) }
-      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+      include_examples("未ログインユーザーに対するアクセス制限のテスト")
     end
   end
 end

--- a/spec/requests/agenda_boards_spec.rb
+++ b/spec/requests/agenda_boards_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.shared_examples("未ログイン時ユーザーに対するアクセス制限のテスト") do
+  it "302リダイレクトを返すこと" do
+    expect(response).to have_http_status(302)
+  end
+
+  it "ログインページにリダイレクトされること" do
+    expect(response).to redirect_to(sign_in_path)
+  end
+
+  it "設定したフラッシュメッセージがセットされていること" do
+    expect(flash[:alert]).to eq("ログインもしくはサインアップが必要です")
+  end
+end
+
+RSpec.describe "AgendaBoards", type: :request do
+  let(:annie) { create(:user, name: "annie") }
+  let!(:about_early_bird) { create(:agenda_board, user_id: annie.id, agenda: "早起きは健康によいのか?", category: "自然科学") }
+
+  context "未ログイン時" do
+    describe "GET /agenda_boards/new" do
+      before { get new_agenda_board_path }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+
+    describe "POST /agenda_boards" do
+      before { post agenda_boards_path }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+
+    describe "GET /agenda_boards/:id" do
+      before { get agenda_board_path(about_early_bird.id) }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+
+    describe "GET /agenda_boards/index_created_by_current_user" do
+      before { get current_user_created_agenda_boards_path }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+
+    describe "GET /agenda_boards/index_with_opinion_posted_by_current_user" do
+      before { get current_user_posted_opinion_agenda_boards_path }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+
+    describe "GET /agenda_boards/index_searched_by_category" do
+      before { get category_search_agenda_boards_path }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+
+    describe "GET /agenda_boards/index_searched_by_agenda" do
+      before { get agenda_search_agenda_boards_path }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+
+    describe "GET /agenda_boards/:id" do
+      before { get edit_agenda_board_path(about_early_bird.id) }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+
+    describe "PATCH /agenda_boards/:id" do
+      before { patch agenda_board_path(about_early_bird.id) }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+
+    describe "DELETE /agenda_boards/:id" do
+      before { delete agenda_board_path(about_early_bird.id) }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+  end
+end

--- a/spec/requests/arguments_spec.rb
+++ b/spec/requests/arguments_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.shared_examples("未ログイン時ユーザーに対するアクセス制限のテスト") do
+  it "302リダイレクトを返すこと" do
+    expect(response).to have_http_status(302)
+  end
+
+  it "ログインページにリダイレクトされること" do
+    expect(response).to redirect_to(sign_in_path)
+  end
+
+  it "設定したフラッシュメッセージがセットされていること" do
+    expect(flash[:alert]).to eq("ログインもしくはサインアップが必要です")
+  end
+end
+
+RSpec.describe "Arguments", type: :request do
+  let(:annie) { create(:user, name: "annie") }
+  let(:about_early_bird) { create(:agenda_board, user_id: annie.id, agenda: "早起きは健康によいのか?", category: "自然科学") }
+
+  let(:very_bad_for_health) do
+    create(:conclusion, agenda_board_id: about_early_bird.id, user_id: annie.id, conclusion_summary: "かなり健康に悪く拷問に等しい")
+  end
+  let(:increased_risk_of_various_diseases) do
+    create(:reason, conclusion_id: very_bad_for_health.id, reason_summary: "早起きは様々な病気のリスクを上げることが明らかになっているから")
+  end
+  let!(:research_data) do
+    create(:evidence, reason_id: increased_risk_of_various_diseases.id, evidence_summary: "早起きが､糖尿病､高血圧などの病気のリスクを上げていることを示す研究データ")
+  end
+
+  context "未ログイン時" do
+    describe "GET /arguments/new" do
+      before { get new_argument_path }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+
+    describe "POST /arguments" do
+      before { post arguments_path }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+
+    describe "GET /arguments/:id" do
+      before { get edit_argument_path(very_bad_for_health.id) }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+
+    describe "PATCH /arguments/:id" do
+      before { patch argument_path(very_bad_for_health.id) }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+
+    describe "DELETE /arguments/:id" do
+      before { delete argument_path(very_bad_for_health.id) }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+  end
+end

--- a/spec/requests/arguments_spec.rb
+++ b/spec/requests/arguments_spec.rb
@@ -14,8 +14,20 @@ RSpec.shared_examples("未ログインユーザーに対するアクセス制限
   end
 end
 
+RSpec.shared_examples("主張の編集/削除に関するアクセス制限のテスト") do
+  it "302リダイレクトを返すこと" do
+    expect(response).to have_http_status(302)
+  end
+
+  it "設定したフラッシュメッセージがセットされていること" do
+    expect(flash[:alert]).to eq("編集/削除する権限があるのは､あなた自身が作成した主張のみです")
+  end
+end
+
 RSpec.describe "Arguments", type: :request do
   let(:annie) { create(:user, name: "annie") }
+  let(:brian) { create(:user, name: "brian") }
+
   let(:about_early_bird) { create(:agenda_board, user_id: annie.id, agenda: "早起きは健康によいのか?", category: "自然科学") }
 
   let(:very_bad_for_health) do
@@ -52,6 +64,39 @@ RSpec.describe "Arguments", type: :request do
     describe "DELETE /arguments/:id" do
       before { delete argument_path(very_bad_for_health.id) }
       include_examples("未ログインユーザーに対するアクセス制限のテスト")
+    end
+  end
+
+  context "既ログイン時" do
+    before { sign_in(brian) }
+
+    describe "以下の権限のない主張の編集/削除に関するリクエストを行った時" do
+      describe "GET /arguments/:id/edit" do
+        before { get edit_argument_path(very_bad_for_health.id) }
+
+        include_examples("主張の編集/削除に関するアクセス制限のテスト")
+        it "編集しようとした主張が所属する議題ボード詳細ページへリダイレクトされること" do
+          expect(response).to redirect_to(agenda_board_path(very_bad_for_health.agenda_board_id))
+        end
+      end
+
+      describe "PATCH /arguments/:id" do
+        before { patch argument_path(very_bad_for_health.id) }
+
+        include_examples("主張の編集/削除に関するアクセス制限のテスト")
+        it "編集しようとした主張が所属する議題ボード詳細ページへリダイレクトされること" do
+          expect(response).to redirect_to(agenda_board_path(very_bad_for_health.agenda_board_id))
+        end
+      end
+
+      describe "DELETE /arguments/:id" do
+        before { delete argument_path(very_bad_for_health.id) }
+
+        include_examples("主張の編集/削除に関するアクセス制限のテスト")
+        it "削除しようとした主張が所属する議題ボード詳細ページへリダイレクトされること" do
+          expect(response).to redirect_to(agenda_board_path(very_bad_for_health.agenda_board_id))
+        end
+      end
     end
   end
 end

--- a/spec/requests/arguments_spec.rb
+++ b/spec/requests/arguments_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.shared_examples("未ログイン時ユーザーに対するアクセス制限のテスト") do
+RSpec.shared_examples("未ログインユーザーに対するアクセス制限のテスト") do
   it "302リダイレクトを返すこと" do
     expect(response).to have_http_status(302)
   end
@@ -31,27 +31,27 @@ RSpec.describe "Arguments", type: :request do
   context "未ログイン時" do
     describe "GET /arguments/new" do
       before { get new_argument_path }
-      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+      include_examples("未ログインユーザーに対するアクセス制限のテスト")
     end
 
     describe "POST /arguments" do
       before { post arguments_path }
-      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+      include_examples("未ログインユーザーに対するアクセス制限のテスト")
     end
 
-    describe "GET /arguments/:id" do
+    describe "GET /arguments/:id/edit" do
       before { get edit_argument_path(very_bad_for_health.id) }
-      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+      include_examples("未ログインユーザーに対するアクセス制限のテスト")
     end
 
     describe "PATCH /arguments/:id" do
       before { patch argument_path(very_bad_for_health.id) }
-      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+      include_examples("未ログインユーザーに対するアクセス制限のテスト")
     end
 
     describe "DELETE /arguments/:id" do
       before { delete argument_path(very_bad_for_health.id) }
-      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+      include_examples("未ログインユーザーに対するアクセス制限のテスト")
     end
   end
 end

--- a/spec/requests/refutations_spec.rb
+++ b/spec/requests/refutations_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Refutations", type: :request do
       include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
     end
 
-    describe "GET /refutations/:id" do
+    describe "GET /refutations/:id/edit" do
       before { get edit_refutation_path(problematic_reason.id) }
       include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
     end

--- a/spec/requests/refutations_spec.rb
+++ b/spec/requests/refutations_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.shared_examples("未ログイン時ユーザーに対するアクセス制限のテスト") do
+  it "302リダイレクトを返すこと" do
+    expect(response).to have_http_status(302)
+  end
+
+  it "ログインページにリダイレクトされること" do
+    expect(response).to redirect_to(sign_in_path)
+  end
+
+  it "設定したフラッシュメッセージがセットされていること" do
+    expect(flash[:alert]).to eq("ログインもしくはサインアップが必要です")
+  end
+end
+
+RSpec.describe "Refutations", type: :request do
+  let(:annie) { create(:user, name: "annie") }
+  let(:brian) { create(:user, name: "brian") }
+
+  let(:about_early_bird) { create(:agenda_board, user_id: annie.id, agenda: "早起きは健康によいのか?", category: "自然科学") }
+
+  let(:very_bad_for_health) do
+    create(:conclusion, agenda_board_id: about_early_bird.id, user_id: annie.id, conclusion_summary: "かなり健康に悪く拷問に等しい")
+  end
+  let(:increased_risk_of_various_diseases) do
+    create(:reason, conclusion_id: very_bad_for_health.id, reason_summary: "早起きは様々な病気のリスクを上げることが明らかになっているから")
+  end
+  let!(:research_data) do
+    create(:evidence, reason_id: increased_risk_of_various_diseases.id, evidence_summary: "早起きが､糖尿病､高血圧などの病気のリスクを上げていることを示す研究データ")
+  end
+
+  let(:problematic_reason) do
+    create(:ref_conclusion, agenda_board_id: about_early_bird.id, user_id: brian.id, ref_conclusion_summary: "理由部分に誤りがある")
+  end
+  let(:individual_differences_in_body_clock) do
+    create(:ref_reason, ref_conclusion_id: problematic_reason.id, ref_reason_summary: "体内時計は､同年齢間においても個人差があり､一律ではないから")
+  end
+  let!(:results_of_sleep_time_survey) do
+    create(:ref_evidence, ref_reason_id: individual_differences_in_body_clock.id, ref_evidence_summary: "8155名のMSFsc調査結果")
+  end
+
+  context "未ログイン時" do
+    describe "GET /refutations/new" do
+      before { get new_refutation_path }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+
+    describe "POST /refutations" do
+      before { post refutations_path }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+
+    describe "GET /refutations/:id" do
+      before { get edit_refutation_path(problematic_reason.id) }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+
+    describe "PATCH /refutations/:id" do
+      before { patch refutation_path(problematic_reason.id) }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+
+    describe "DELETE /refutations/:id" do
+      before { delete refutation_path(problematic_reason.id) }
+      include_examples("未ログイン時ユーザーに対するアクセス制限のテスト")
+    end
+  end
+end


### PR DESCRIPTION
## 関連するチケット､Issue､プルリクエストのリンク

* #31

## なぜこの変更をするのか

* セキュリティ向上のため(詳細は #31 を参考)

## やったこと

1. 未ログインユーザーが､ホームページ以外にアクセスしたら､警告メッセージを表示し､ログインページにリダイレクトするよう設定
3. 議題ボードの編集/削除を､非作成者のユーザーが実行しようとしたら､警告メッセージを表示し､そのユーザーが作成した議題ボード一覧ページにリダイレクトするよう設定
4. 主張の編集/削除を､非作成者のユーザーが実行しようとしたら､警告メッセージを表示し､その主張が属する議題ボード詳細ページにリダイレクトするよう設定
5. 反論の編集/削除を､非作成者のユーザーが実行しようとしたら､警告メッセージを表示し､その反論が属する議題ボード詳細ページにリダイレクトするよう設定

## やらないこと

* 無し

## 変更内容
### 1. 未ログイン時  GET /agenda_boards
#### -1. GET /agenda_boards/new
##### before

https://github.com/tikuwabux/VisualDiscussion/assets/111355072/5a8fc19b-cf10-4ec9-98b5-604983b2d23c


##### after


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/86938c5b-0332-4306-8307-31d93d6fa0eb



#### -2. GET /agenda_boards/:id
##### before


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/aa9779aa-76b1-4e5d-a0b3-b67f39340fb6


##### after


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/eee8525e-fcea-4caa-9506-e82ad9c919bd


#### -3. GET /agenda_boards/index_created_by_current_user
##### before

https://github.com/tikuwabux/VisualDiscussion/assets/111355072/d439949e-9c82-43cf-abc5-31801692a336


##### after


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/4e5240b3-5d53-48b2-8679-41233d0b65ad



#### -4. GET /agenda_boards/index_with_opinion_posted_by_current_user
##### before


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/91f95aea-7341-4783-aeaa-915651efb0f0


##### after


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/79cfe1c5-6315-4ead-97f9-0efd5767809a



#### -5. GET /agenda_boards/index_searched_by_category
##### before

https://github.com/tikuwabux/VisualDiscussion/assets/111355072/e098c5e3-71c9-4925-8fea-66c440231230



##### after



https://github.com/tikuwabux/VisualDiscussion/assets/111355072/90142841-dc66-4509-bacf-7d7126ecd6f9




#### -6. GET /agenda_boards/index_searched_by_agenda
##### before

https://github.com/tikuwabux/VisualDiscussion/assets/111355072/4425b41c-1e35-43b1-a1ff-45036ffc5ce8



##### after



https://github.com/tikuwabux/VisualDiscussion/assets/111355072/6d74021d-ebf2-4974-b8d1-2ce6ef125c26



#### -7. GET /agenda_boards/:id/edit
##### before


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/a184bf20-f11e-4724-a279-af713fd5d81b



##### after



https://github.com/tikuwabux/VisualDiscussion/assets/111355072/45d29c39-486f-466f-a27c-126705ba55a8




### 2. 既ログイン時  GET /agenda_boards/:id/edit (id値は編集権限のない議題ボードのid値)
#### before


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/a9d5c501-fc80-4646-8cfe-2a79d6e4bbba



#### after


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/ad4879b1-b766-4321-b2a0-c5d11d2d3c3c


### 3. 未ログイン時  GET /arguments
#### -1. GET /arguments/new
##### before


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/040f200c-02be-499f-ba1f-1caf2e3d08e9



##### after


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/11d1acb0-08a1-4fb7-bf5b-7b49ccdcaa12




#### -2. GET /arguments/:id/edit
##### before



https://github.com/tikuwabux/VisualDiscussion/assets/111355072/a09c2d4e-b8d0-4b48-99e9-d97ee8ec4fce


##### after

https://github.com/tikuwabux/VisualDiscussion/assets/111355072/9eed4ead-5588-489d-95e3-5bfd8df42ce8



### 4. 既ログイン時  GET /arguments/:id/edit (id値は編集権限のない主張のid値)
#### before


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/59b2ff4c-bbd0-4bc7-9a7f-72d4c1617f87


#### after

https://github.com/tikuwabux/VisualDiscussion/assets/111355072/2544dd4a-b687-44ac-8cef-698d53299d2d




### 5. 未ログイン時  GET /refutations
#### -1. GET /refutations/new
##### before


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/c5030b1b-a974-4054-80ce-83865cd669d7



##### after


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/7cac7713-915b-4b7d-be0d-966ac9b7231d



#### -2. GET /refutations/:id/edit
##### before


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/28c4b91c-00a9-4b10-a74c-73529c03524f



##### after



https://github.com/tikuwabux/VisualDiscussion/assets/111355072/73ebe7d6-b793-44db-ab80-ff2bb242e67a




### 6. GET /refutations/:id/edit (id値は編集権限のない反論のid値)
#### before


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/afda82a7-4ace-4fa4-a63b-070e09ee2abc



#### after


https://github.com/tikuwabux/VisualDiscussion/assets/111355072/d0e5252c-d9cc-4e73-8704-4dab02407d80




## できるようになること（ユーザ目線）

*  自分が作成した議題ボード､主張､反論が他ユーザーによって､編集/削除されることを防止すること
## できなくなること（ユーザ目線）

1. 未ログイン時にホームページ以外へアクセスすること
2. 他ユーザーが作成した議題ボードの編集/削除を行うこと
3. 他ユーザーが作成した主張の編集/削除を行うこと
4.他ユーザーが作成した反論の編集/削除を行うこと


## 動作確認

### 開発環境下
#### リクエストスペックを実装し､追加したアクセス制限をテストした結果､すべてのテストをパスした｡

以下はすべて今回追加したテスト
![リクエストスペック1](https://github.com/tikuwabux/VisualDiscussion/assets/111355072/c955b775-6306-439c-84e4-37b8e8738833)

![リクエストスペック2](https://github.com/tikuwabux/VisualDiscussion/assets/111355072/28211e05-aeb5-406c-a759-a578442ef1d8)
## その他

* 無し
