### PR TITLE
アプリの使い方説明動画を差し替える

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -16,6 +16,7 @@
 
 .usage_explanation {
   text-align: left;
+  width: 100%;
 
   p {
     font-size: 15px;
@@ -24,6 +25,20 @@
   .red_annotation {
     color: red;
     font-weight: bold;
+  }
+}
+
+.explanation_of_usage_video {
+  position: relative;
+  padding-bottom: 56.25%; /* 16:9 の縦横比を保つためのパディング */
+  height: 0;
+
+  iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
   }
 }
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -5,11 +5,12 @@
   </div>
   <div class="main_wrapper">
     <div class="usage_explanation">
-      <h2>【VisuDis使い方解説動画】</h2>
-      <p>※ 音声無し､字幕のみの解説動画です｡</p>
+      <h2>【VisuDis使い方 字幕解説】</h2>
       <p>※ PCでアプリを使用しながら解説しています｡</p>
       <p class="red_annotation">※ 本アプリはPCでの使用を強く推奨します｡</p>
-      <%= video_tag "/videos/sample_movie.mp4", controls: true, muted: true, width: "100%", class: "sample_movie" %>
+      <div class="explanation_of_usage_video">
+        <iframe src="https://www.youtube.com/embed/BCmfp9Dlnu0" title="【VisuDis使い方 字幕解説】" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      </div>
     </div>
     <div class="overview">
       <h2>VisuDisuとは?</h2>


### PR DESCRIPTION
## 関連するチケット､Issue､プルリクエストのリンク

#37 
## なぜこの変更をするのか

*  変更前の字幕なしの動画では､分かりづらいから｡

## やったこと

* アプリの使い方説明動画を字幕付きのものに差し替え､ 動画タイトルの文言を変更した｡

## やらないこと

* 無し

## 変更内容

### 1. 動画タイトルを含めた全体のレイアウト

#### before
<img width="1161" alt="解説動画 画像 before" src="https://github.com/tikuwabux/VisualDiscussion/assets/111355072/6df59827-9bda-433b-b954-86b6cab815e6">

#### after

<img width="1142" alt="解説動画 画像 after" src="https://github.com/tikuwabux/VisualDiscussion/assets/111355072/87203051-a3b5-4d6e-8e1e-06407f770f94">



### 2. 解説動画の内容

#### before

容量オーバーのため､ファイル添付不可｡ また､ youtubeにアップロードしていないので､リンクの添付も不可｡
#### after

https://youtu.be/BCmfp9Dlnu0

## できるようになること（ユーザ目線）

* アプリの使い方の理解が容易になる｡

## できなくなること（ユーザ目線）

* 無し

## 動作確認

開発環境で､全テストを実行した結果､全てパスした｡
<img width="587" alt="テスト 前半" src="https://github.com/tikuwabux/VisualDiscussion/assets/111355072/e86798b3-7102-4ee0-96dc-009b997fe09e">

中略

<img width="674" alt="テスト 後半" src="https://github.com/tikuwabux/VisualDiscussion/assets/111355072/2f56ef6b-e6f8-46e3-8b20-7e3d30a7a8f5">



## その他

実装は以下のサイトを参考にした｡
https://qiita.com/Naoya_pro/items/a8e992c40b69c88ed9e2
