### PR TITLE
トップページ中の文章を修正する

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -109,6 +109,16 @@
     gap: 40px;
   }
 
+  .pink_text {
+    color: #CC99CC;
+    font-weight: bold;
+  }
+
+  .blue_text {
+    color: #0094D6;
+    font-weight: bold;
+  }
+
   p {
     font-size: 15px;
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -40,7 +40,7 @@
         </div>
         <div class="visualized_information">
           <h3>③ どの反論が､どの意見の<br>
-            どの要素に対して､<br>
+            どの部分に対して､<br>
             批判を提示しているのか
           </h3>
             <div class="red_connection_images">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -29,7 +29,7 @@
             <%= image_tag "visualized_info1_2.png", width: "100%", class: "vertical_alignment_image" %>
           <p>意見を｢主張｣と｢反論｣の2種類に大別し､<br>
             両者を色で判別できるよう､<br>
-            ｢主張｣を｢青｣､｢反論｣を｢ピンク｣で色分け</p>
+            ｢主張｣を｢ピンク｣､｢反論｣を｢青｣で色分け</p>
         </div>
         <div class="visualized_information">
           <h3>② 意見の構成</h3>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -15,7 +15,7 @@
     <div class="overview">
       <h2>VisuDisuとは?</h2>
       <ul>
-        <li><strong>文章のやりとりを通じてディスカッションを行いたい人</strong>  に向けた､</li>
+        <li><strong>文面のやりとりを通じてディスカッションを行いたい人</strong>  に向けた､</li>
         <li><strong>視覚的に分かりやすいディスカッションを行う</strong>  ための､</li>
         <li><strong>ディスカッション情報を視覚化することに特化したコミュニュケーションアプリ</strong></li>
       </ul>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -29,7 +29,7 @@
             <%= image_tag "visualized_info1_2.png", width: "100%", class: "vertical_alignment_image" %>
           <p>意見を｢主張｣と｢反論｣の2種類に大別し､<br>
             両者を色で判別できるよう､<br>
-            ｢主張｣を｢ピンク｣､｢反論｣を｢青｣で色分け</p>
+            ｢主張｣を｢<span class="pink_text">ピンク</span>｣､｢反論｣を｢<span class="blue_text">青</span>｣で色分け</p>
         </div>
         <div class="visualized_information">
           <h3>② 意見の構成</h3>


### PR DESCRIPTION
## 関連するチケット､Issue､プルリクエストのリンク

* #37

## なぜこの変更をするのか

* UI/UX向上のため

## やったこと

*  トップページ中の文章を適切なものに修正した

## やらないこと

* 無し
## 変更内容
### トップページ
### before

<img width="1360" alt="#40 before" src="https://github.com/tikuwabux/VisualDiscussion/assets/111355072/808a0db7-4a27-488e-969a-b0b3be68e387">

### after
<img width="1356" alt="#40 after" src="https://github.com/tikuwabux/VisualDiscussion/assets/111355072/54bdc3a5-9c23-4fed-8bc0-43cf260e74d4">


## できるようになること（ユーザ目線）

* 無し

## できなくなること（ユーザ目線）

* 無し

## 動作確認

開発環境で､全テストを実行した結果､全てパスした｡
<img width="587" alt="テスト 前半" src="https://github.com/tikuwabux/VisualDiscussion/assets/111355072/e86798b3-7102-4ee0-96dc-009b997fe09e">

中略

<img width="674" alt="テスト 後半" src="https://github.com/tikuwabux/VisualDiscussion/assets/111355072/2f56ef6b-e6f8-46e3-8b20-7e3d30a7a8f5">



## その他

* 特に無し
